### PR TITLE
Add parent app sync env var

### DIFF
--- a/aoa-tools/deploy.sh
+++ b/aoa-tools/deploy.sh
@@ -49,6 +49,7 @@ echo ""
 echo "Github Account: $github_username"
 echo "Repo: $repo_name"
 echo "Branch: $target_branch"
+echo "Automatic Sync: $parent_app_sync"
 echo "------------------------------------------------------------"
 
 echo "Continue? [y/N]"
@@ -260,7 +261,7 @@ do
    done 
 
   # deploy aoa wave
-  $SCRIPT_DIR/tools/configure-wave.sh ${normalized_wave_location} ${wave_name} ${cluster_context} ${github_username} ${repo_name} ${target_branch}
+  $SCRIPT_DIR/tools/configure-wave.sh ${normalized_wave_location} ${wave_name} ${cluster_context} ${github_username} ${repo_name} ${target_branch} ${parent_app_sync}
   # TODO: extract the pre and post script deploy in a function to avoid dup 
   # Post deploy scripts
    script_count=`cat catalog.yaml | yq ".waves[$c].scripts.post_deploy | length"`

--- a/aoa-tools/tools/configure-wave.sh
+++ b/aoa-tools/tools/configure-wave.sh
@@ -7,6 +7,7 @@ cluster_context=${3:-""}
 github_username=${4:-""}
 repo_name=${5:-""}
 target_branch=${6:-""}
+parent_app_sync=$7
 
 # check to see if wave name variable was passed through, if not prompt for it
 if [[ ${wave_name} == "" ]]
@@ -48,6 +49,14 @@ if [[ ${target_branch} == "" ]]
     read target_branch
 fi
 
+# check to see if parent_app_sync variable was passed through, if not prompt for it
+if [[ ${parent_app_sync} == "" ]]
+  then
+    # provide parent_app_sync variable
+    echo "Please provide the parent_app_sync to use (i.e. HEAD):"
+    read parent_app_sync
+fi
+
 kubectl --context ${cluster_context} apply -f - <<EOF
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -61,13 +70,13 @@ spec:
   source:
     repoURL: https://github.com/${github_username}/${repo_name}/
     targetRevision: ${target_branch}
-    path: $path
+    path: ${path}
   destination:
     server: https://kubernetes.default.svc
   syncPolicy:
     automated:
-      prune: true
-      selfHeal: true
+      prune: ${parent_app_sync}
+      selfHeal: ${parent_app_sync}
     retry:
       limit: 2
       backoff:

--- a/environments/gloo-edge/flagger-podinfo/vars.env
+++ b/environments/gloo-edge/flagger-podinfo/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_LICENSE_KEY"
-environment_name="gloo-edge/flagger-podinfo"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-edge/httpbin-bookinfo/vars.env
+++ b/environments/gloo-edge/httpbin-bookinfo/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_LICENSE_KEY"
-environment_name="gloo-edge/httpbin-bookinfo"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/bookinfo/glootest.com/vars.env
+++ b/environments/gloo-gateway/bookinfo/glootest.com/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/bookinfo/glootest.com"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/bookinfo/ilm/vars.env
+++ b/environments/gloo-gateway/bookinfo/ilm/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/bookinfo/ilm"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/bookinfo/vars.env
+++ b/environments/gloo-gateway/bookinfo/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/bookinfo"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/core/glootest.com/vars.env
+++ b/environments/gloo-gateway/core/glootest.com/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/core/glootest.com"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/core/vars.env
+++ b/environments/gloo-gateway/core/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/freestyle"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/httpbin/glootest.com/vars.env
+++ b/environments/gloo-gateway/httpbin/glootest.com/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/httpbin/glootest.com"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/httpbin/ilm/vars.env
+++ b/environments/gloo-gateway/httpbin/ilm/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/httpbin/ilm"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/httpbin/vars.env
+++ b/environments/gloo-gateway/httpbin/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/httpbin"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/onlineboutique/glootest.com/vars.env
+++ b/environments/gloo-gateway/onlineboutique/glootest.com/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/onlineboutique/wildcard-host"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/onlineboutique/ilm/vars.env
+++ b/environments/gloo-gateway/onlineboutique/ilm/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/onlineboutique/ilm"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/onlineboutique/tracing/vars.env
+++ b/environments/gloo-gateway/onlineboutique/tracing/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/onlineboutique/tracing"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/onlineboutique/vars.env
+++ b/environments/gloo-gateway/onlineboutique/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/onlineboutique"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/portal/vars.env
+++ b/environments/gloo-gateway/portal/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/portal-v2"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/glootest.com/vars.env
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/glootest.com/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/progressive-delivery-argo-rollouts/glootest.com"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/ilm/vars.env
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/ilm/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/progressive-delivery-argo-rollouts/ilm"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/vars.env
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/vars.env
@@ -6,4 +6,4 @@
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
 cluster_context="mgmt"
-parent_app_sync="true"
+parent_app_sync="false"

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/vars.env
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/progressive-delivery-argo-rollouts-otel"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/solowallet/glootest.com/vars.env
+++ b/environments/gloo-gateway/solowallet/glootest.com/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/solowallet/glootest.com"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/solowallet/ilm/vars.env
+++ b/environments/gloo-gateway/solowallet/ilm/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/solowallet/ilm"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-gateway/solowallet/vars.env
+++ b/environments/gloo-gateway/solowallet/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-environment_name="gloo-gateway/solowallet"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/core/cluster1/vars.env
+++ b/environments/gloo-platform/core/cluster1/vars.env
@@ -5,6 +5,6 @@
 # rename your context if necessary
 
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/core/cluster1"
 cluster_context="cluster1"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/core/cluster2/vars.env
+++ b/environments/gloo-platform/core/cluster2/vars.env
@@ -5,6 +5,6 @@
 # rename your context if necessary
 
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/core/cluster2"
 cluster_context="cluster2"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/core/mgmt/vars.env
+++ b/environments/gloo-platform/core/mgmt/vars.env
@@ -6,6 +6,6 @@
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/core/mgmt"
 cluster_context="mgmt"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster1/vars.env
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster1/vars.env
@@ -5,6 +5,6 @@
 # rename your context if necessary
 
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/multicluster-bookinfo-httpbin/cluster1"
 cluster_context="cluster1"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster2/vars.env
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster2/vars.env
@@ -5,6 +5,6 @@
 # rename your context if necessary
 
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/multicluster-bookinfo-httpbin/cluster2"
 cluster_context="cluster2"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/glootest.com/vars.env
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/glootest.com/vars.env
@@ -6,6 +6,6 @@
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/multicluster-bookinfo-httpbin/mgmt/glootest.com"
 cluster_context="mgmt"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/vars.env
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/vars.env
@@ -6,6 +6,6 @@
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/multicluster-bookinfo-httpbin/mgmt"
 cluster_context="mgmt"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster1/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster1/vars.env
@@ -5,6 +5,6 @@
 # rename your context if necessary
 
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/multicluster-onlineboutique/cluster1"
 cluster_context="cluster1"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster1/wildcard-host/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster1/wildcard-host/vars.env
@@ -5,6 +5,6 @@
 # rename your context if necessary
 
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/multicluster-onlineboutique/cluster1/wildcard-hosts"
 cluster_context="cluster1"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster2/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster2/vars.env
@@ -5,6 +5,6 @@
 # rename your context if necessary
 
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/multicluster-onlineboutique/cluster2"
 cluster_context="cluster2"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster2/wildcard-host/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster2/wildcard-host/vars.env
@@ -5,6 +5,6 @@
 # rename your context if necessary
 
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/multicluster-onlineboutique/cluster2/wildcard-host"
 cluster_context="cluster2"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/glootest.com/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/glootest.com/vars.env
@@ -6,6 +6,6 @@
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/multicluster-onlineboutique/mgmt/glootest.com"
 cluster_context="mgmt"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/vars.env
@@ -6,6 +6,6 @@
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/multicluster-onlineboutique/mgmt"
 cluster_context="mgmt"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/wildcard-host/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/wildcard-host/vars.env
@@ -6,6 +6,6 @@
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/multicluster-onlineboutique/mgmt/wildcard-host"
 cluster_context="mgmt"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/cluster1/vars.env
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/cluster1/vars.env
@@ -5,6 +5,6 @@
 # rename your context if necessary
 
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/multicluster-podinfo-weighted-subset-failover/cluster1"
 cluster_context="cluster1"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/cluster2/vars.env
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/cluster2/vars.env
@@ -5,6 +5,6 @@
 # rename your context if necessary
 
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/multicluster-podinfo-weighted-subset-failover/cluster2"
 cluster_context="cluster2"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/glootest.com/vars.env
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/glootest.com/vars.env
@@ -6,6 +6,6 @@
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/glootest.com"
 cluster_context="mgmt"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/vars.env
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/vars.env
@@ -6,6 +6,6 @@
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
 gloo_mesh_version="2.3.7"
-environment_name="gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt"
 cluster_context="mgmt"
 mgmt_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-portal/petstore-portal/vars.env
+++ b/environments/gloo-portal/petstore-portal/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_LICENSE_KEY"
-environment_name="gloo-portal/petstore-portal"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/gloo-portal/solo-dev-portal/vars.env
+++ b/environments/gloo-portal/solo-dev-portal/vars.env
@@ -5,5 +5,5 @@
 # rename your context if necessary
 
 license_key="$GLOO_LICENSE_KEY"
-environment_name="gloo-portal/solo-dev-portal"
 cluster_context="mgmt"
+parent_app_sync="true"

--- a/environments/istio/basic-demo/vars.env
+++ b/environments/istio/basic-demo/vars.env
@@ -4,5 +4,5 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-environment_name="istio/basic-demo"
 cluster_context="mgmt"
+parent_app_sync="true"


### PR DESCRIPTION
with the `parent_app_sync="true/false"` variable added to your environment `vars.env` you can now turn optionally turn off sync and prune behavior for parent app-of-apps. This is helpful for local development where changing versions, images, or tags is done more often