### PR TITLE
0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,10 @@
 # Changelog
 
-0.1 (11-10-23)
+0.1.2 (11-16-23)
 ---
-- add clickhouse portal analytics to `gloo-gateway/int-ext-portal`
-- migrate from istio samples grafana to grafana helm chart for gloo-gateway and gloo-platform environments
-- add gloo platform ops dashboard to gloo-gateway and gloo-platform environments
-- set istio before gloo-platform in catalog.yaml for gloo-gateway environments so that gloo-mesh-addons start up with istio-proxy sidecars
-- set istio before gloo-platform in catalog.yaml for gloo-platform environments so that gloo-mesh-addons start up with istio-proxy sidecars
-- update onlineboutique images to `us-central1-docker.pkg.dev/field-engineering-us/online-boutique` builds in `environments/gloo-gateway`
-- validate all `gloo-gateway` environments (localhost / hostname / ILM overlays) working locally with k3d on x86 and M1 Macbook Pro
----
+- update gloo-portal/solo-dev-portal to use gloo-portal 1.3.3
+- update gloo-edge/argo-rollouts canary example service names to match blog. stable/canary > active/preview
+
 
 0.1.1 (11-13-23)
 ---
@@ -21,3 +16,14 @@
     - gloo-edge/flagger-podinfo to 1.15.7
     - gloo-portal/solo-dev-portal to gloo edge 1.15.7
 - add homer portal to gloo-edge/httpbin-bookinfo to simplify navigation
+
+
+0.1.0 (11-10-23)
+---
+- add clickhouse portal analytics to `gloo-gateway/int-ext-portal`
+- migrate from istio samples grafana to grafana helm chart for gloo-gateway and gloo-platform environments
+- add gloo platform ops dashboard to gloo-gateway and gloo-platform environments
+- set istio before gloo-platform in catalog.yaml for gloo-gateway environments so that gloo-mesh-addons start up with istio-proxy sidecars
+- set istio before gloo-platform in catalog.yaml for gloo-platform environments so that gloo-mesh-addons start up with istio-proxy sidecars
+- update onlineboutique images to `us-central1-docker.pkg.dev/field-engineering-us/online-boutique` builds in `environments/gloo-gateway`
+- validate all `gloo-gateway` environments (localhost / hostname / ILM overlays) working locally with k3d on x86 and M1 Macbook Pro

--- a/environments/gloo-edge/argo-rollouts/rollouts-demo/rollouts-demo/strategies/canary-single-rt/base/kustomization.yaml
+++ b/environments/gloo-edge/argo-rollouts/rollouts-demo/rollouts-demo/strategies/canary-single-rt/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- rollouts-demo-deploy.yaml
+#- rollouts-demo-deploy.yaml
 - rollouts-demo-ns.yaml
 - rollouts-demo-rollout.yaml
 - rollouts-demo-service.yaml

--- a/environments/gloo-edge/argo-rollouts/rollouts-demo/rollouts-demo/strategies/canary-single-rt/base/rollouts-demo-rollout.yaml
+++ b/environments/gloo-edge/argo-rollouts/rollouts-demo/rollouts-demo/strategies/canary-single-rt/base/rollouts-demo-rollout.yaml
@@ -1,7 +1,13 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rollouts-demo
+  namespace: rollouts-demo
+---
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
-  name: rollouts-demo-rollout
+  name: rollouts-demo
   namespace: rollouts-demo
 spec:
   selector:
@@ -24,16 +30,17 @@ spec:
           requests:
             cpu: 5m
             memory: 32Mi
+      serviceAccount: rollouts-demo
   strategy:
     canary:
-      canaryService: rollouts-demo-canary
-      stableService: rollouts-demo-stable
+      stableService: rollouts-demo-active
+      canaryService: rollouts-demo-preview
       trafficRouting:
         plugins:
           solo-io/glooedge:
             routeTable:
               name: rollouts-demo-routes
-              namespace: rollouts-demo
+              namespace: gloo-system
       steps:
         - setWeight: 10
         - pause: {duration: 5}

--- a/environments/gloo-edge/argo-rollouts/rollouts-demo/rollouts-demo/strategies/canary-single-rt/base/rollouts-demo-service.yaml
+++ b/environments/gloo-edge/argo-rollouts/rollouts-demo/rollouts-demo/strategies/canary-single-rt/base/rollouts-demo-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: rollouts-demo-stable
+  name: rollouts-demo-active
   namespace: rollouts-demo
   labels:
     app: rollouts-demo
@@ -17,7 +17,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: rollouts-demo-canary
+  name: rollouts-demo-preview
   namespace: rollouts-demo
   labels:
     app: rollouts-demo

--- a/environments/gloo-edge/argo-rollouts/rollouts-demo/rollouts-demo/strategies/canary-single-rt/base/rollouts-demo-vs-rt.yaml
+++ b/environments/gloo-edge/argo-rollouts/rollouts-demo/rollouts-demo/strategies/canary-single-rt/base/rollouts-demo-vs-rt.yaml
@@ -1,26 +1,26 @@
 apiVersion: gloo.solo.io/v1
 kind: Upstream
 metadata:
-  name: rollouts-demo-stable
+  name: rollouts-demo-active
   namespace: rollouts-demo 
 spec:
   kube:
     selector:
       app: rollouts-demo
-    serviceName: rollouts-demo-stable
+    serviceName: rollouts-demo-active
     serviceNamespace: rollouts-demo
     servicePort: 8080
 ---
 apiVersion: gloo.solo.io/v1
 kind: Upstream
 metadata:
-  name: rollouts-demo-canary
+  name: rollouts-demo-preview
   namespace: rollouts-demo
 spec:
   kube:
     selector:
       app: rollouts-demo
-    serviceName: rollouts-demo-canary
+    serviceName: rollouts-demo-preview
     serviceNamespace: rollouts-demo
     servicePort: 8080
 ---
@@ -28,7 +28,7 @@ apiVersion: gateway.solo.io/v1
 kind: RouteTable
 metadata:
   name: rollouts-demo-routes
-  namespace: rollouts-demo
+  namespace: gloo-system
 spec:
   routes:
     - matchers:
@@ -38,9 +38,14 @@ spec:
           destinations:
           - destination:
               upstream:
-                name: rollouts-demo-stable
+                name: rollouts-demo-active
                 namespace: rollouts-demo
             weight: 100
+          - destination:
+              upstream:
+                name: rollouts-demo-preview
+                namespace: rollouts-demo
+            weight: 0
 ---
 apiVersion: gateway.solo.io/v1
 kind: VirtualService
@@ -57,4 +62,4 @@ spec:
       delegateAction:
         ref:
           name: rollouts-demo-routes
-          namespace: rollouts-demo
+          namespace: gloo-system

--- a/environments/gloo-edge/argo-rollouts/rollouts-demo/rollouts-demo/test.sh
+++ b/environments/gloo-edge/argo-rollouts/rollouts-demo/rollouts-demo/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # wait for rollouts-demo success
-until kubectl argo rollouts status --timeout 300s rollouts-demo-rollout -n rollouts-demo --context ${cluster_context} 2> /dev/null; do sleep 2; done
+until kubectl argo rollouts status --timeout 300s rollouts-demo -n rollouts-demo --context ${cluster_context} 2> /dev/null; do sleep 2; done

--- a/environments/gloo-portal/solo-dev-portal/README.md
+++ b/environments/gloo-portal/solo-dev-portal/README.md
@@ -11,7 +11,7 @@ The `gloo-portal/solo-dev-portal` environment deploys a Gloo Edge, Gloo Portal, 
 ## Environment description
 - base:
     - Gloo Edge Enterprise 1.15.7
-    - Gloo Portal 1.3.2
+    - Gloo Portal 1.3.3
 
 ## Application description
 

--- a/environments/gloo-portal/solo-dev-portal/gloo-portal-app/base/gloo-portal-helm.yaml
+++ b/environments/gloo-portal/solo-dev-portal/gloo-portal-app/base/gloo-portal-helm.yaml
@@ -26,7 +26,7 @@ spec:
             namespace: gloo-system
             key: license-key
     repoURL: https://storage.googleapis.com/dev-portal-helm
-    targetRevision: 1.3.2
+    targetRevision: 1.3.3
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).


### PR DESCRIPTION
0.1.2 (11-16-23)
---
- update gloo-portal/solo-dev-portal to use gloo-portal 1.3.3
- update gloo-edge/argo-rollouts canary example service names to match blog. stable/canary > active/preview