### PR TITLE
see changelog (0.1.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+0.1.9 (12-1-23)
+---
+- remove the number suffix after each wave (i.e. wave-0-clusterconfig to wave-clusterconfig). This helps allows us to re-order the waves more easily. It is assumed that the `catalog.yaml` list will run in descending order.
+- update the wait command for Gloo Platform CRDs in `core/gloo-platform/test.sh` to run silently
+
 0.1.8 (11-30-23)
 ---
 - Add upstream istio/ambient-demo environment to catalog

--- a/aoa-tools/deploy.sh
+++ b/aoa-tools/deploy.sh
@@ -264,7 +264,7 @@ execute_scripts() {
 
 for ((c = 0; c < $waves_count; c++)); do
   wave_name=$(echo "$catalog_content" | yq -r ".waves[$c].name")
-  wave_name="${c}-${wave_name:-$c}"
+  wave_name="${wave_name:-$c}"
 
   wave_location=$(echo "$catalog_content" | yq -r ".waves[$c].location")
   normalized_wave_location=$(eval echo $wave_location)

--- a/environments/gloo-gateway/core/gloo-platform/test.sh
+++ b/environments/gloo-gateway/core/gloo-platform/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-until kubectl --context ${cluster_context} -n gloo-mesh wait --for condition=established crd/kubernetesclusters.admin.gloo.solo.io ; do sleep 10; done
+until kubectl --context ${cluster_context} -n gloo-mesh wait --for condition=established crd/kubernetesclusters.admin.gloo.solo.io > /dev/null 2>&1; do sleep 10; done
 
 kubectl apply --context ${cluster_context} -f- <<EOF
 apiVersion: admin.gloo.solo.io/v2

--- a/environments/gloo-platform/core/mgmt/gloo-platform/test.sh
+++ b/environments/gloo-platform/core/mgmt/gloo-platform/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-until kubectl --context ${cluster_context} -n gloo-mesh wait --for condition=established crd/kubernetesclusters.admin.gloo.solo.io ; do sleep 10; done
+until kubectl --context ${cluster_context} -n gloo-mesh wait --for condition=established crd/kubernetesclusters.admin.gloo.solo.io > /dev/null 2>&1; do sleep 10; done
 
 kubectl apply --context ${cluster_context} -f- <<EOF
 apiVersion: admin.gloo.solo.io/v2


### PR DESCRIPTION
0.1.9 (12-1-23)
---
- remove the number suffix after each wave (i.e. wave-0-clusterconfig to wave-clusterconfig). This helps allows us to re-order the waves more easily. It is assumed that the `catalog.yaml` list will run in descending order.
- update the wait command for Gloo Platform CRDs in `core/gloo-platform/test.sh` to run silently