### PR TITLE
see changelog (0.1.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+0.1.12 (12-7-23)
+---
+- Specify `${mgmt_context}` cluster context for in the `gloo-platform/core/shared-components/homer-config/test.sh` to properly output the correct LB URL of the mgmt istio ingressgateway for the homer dashboard.
+- Specify `${cluster_context}` for in the `gloo-gateway/core/homer-config/test.sh` to ensure the correct LB URL of the istio ingressgateway for the homer dashboard.
+
 0.1.11 (12-4-23)
 ---
 - switch back to using otel daemonset instead of deployment in gloo-platform environments

--- a/environments/gloo-gateway/core/homer-config/test.sh
+++ b/environments/gloo-gateway/core/homer-config/test.sh
@@ -7,7 +7,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"

--- a/environments/gloo-platform/core/shared-components/homer-config/test.sh
+++ b/environments/gloo-platform/core/shared-components/homer-config/test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-ISTIO_REVISION="1-19"
-
 echo 
 echo "Installation complete:"
 echo "A homepage has been exposed at the Gloo Gateway wildcard '*' host to simplify navigation"
@@ -9,7 +7,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${mgmt_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"


### PR DESCRIPTION
0.1.12 (12-7-23)
---
- Specify `${mgmt_context}` cluster context for in the `gloo-platform/core/shared-components/homer-config/test.sh` to properly output the correct LB URL of the mgmt istio ingressgateway for the homer dashboard.
- Specify `${cluster_context}` for in the `gloo-gateway/core/homer-config/test.sh` to ensure the correct LB URL of the istio ingressgateway for the homer dashboard.