### PR TITLE
see changelog (0.1.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+0.1.13 (12-18-23)
+---
+- update rollouts-ui-dashboard to `quay.io/argoproj/kubectl-argo-rollouts:v1.6.4`
+
 0.1.12 (12-7-23)
 ---
 - Specify `${mgmt_context}` cluster context for in the `gloo-platform/core/shared-components/homer-config/test.sh` to properly output the correct LB URL of the mgmt istio ingressgateway for the homer dashboard.

--- a/environments/gloo-edge/argo-rollouts/echo/echo-rollout/strategies/rollouts-ui/rollouts-ui-deploy.yaml
+++ b/environments/gloo-edge/argo-rollouts/echo/echo-rollout/strategies/rollouts-ui/rollouts-ui-deploy.yaml
@@ -45,7 +45,7 @@ spec:
         app.kubernetes.io/name: argo-rollouts-dashboard
     spec:
       containers:
-      - image: quay.io/argoproj/kubectl-argo-rollouts:latest
+      - image: quay.io/argoproj/kubectl-argo-rollouts:v1.6.4
         name: argo-rollouts-dashboard
         ports:
         - containerPort: 3100

--- a/environments/gloo-edge/argo-rollouts/rollouts-demo/rollouts-demo/strategies/rollouts-ui/rollouts-ui-deploy.yaml
+++ b/environments/gloo-edge/argo-rollouts/rollouts-demo/rollouts-demo/strategies/rollouts-ui/rollouts-ui-deploy.yaml
@@ -45,7 +45,7 @@ spec:
         app.kubernetes.io/name: argo-rollouts-dashboard
     spec:
       containers:
-      - image: quay.io/argoproj/kubectl-argo-rollouts:latest
+      - image: quay.io/argoproj/kubectl-argo-rollouts:v1.6.4
         name: argo-rollouts-dashboard
         ports:
         - containerPort: 3100

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/rollouts-demo/base/rollouts-ui/rollouts-ui-deploy.yaml
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/rollouts-demo/base/rollouts-ui/rollouts-ui-deploy.yaml
@@ -47,7 +47,7 @@ spec:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     spec:
       containers:
-      - image: quay.io/argoproj/kubectl-argo-rollouts:latest
+      - image: quay.io/argoproj/kubectl-argo-rollouts:v1.6.4
         name: argo-rollouts-dashboard
         ports:
         - containerPort: 3100


### PR DESCRIPTION
0.1.13 (12-18-23)
---
- update rollouts-ui-dashboard to `quay.io/argoproj/kubectl-argo-rollouts:v1.6.4`