### PR TITLE
see CHANGELOG (0.1.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+0.1.14 (12-27-23)
+---
+- update homer image to ably77/homer:0.1.0 (adds glooy logo)
+- add --context to homer output command: 
+```
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')/solo"
+```
+
 0.1.13 (12-18-23)
 ---
 - update rollouts-ui-dashboard to `quay.io/argoproj/kubectl-argo-rollouts:v1.6.4`

--- a/environments/gloo-edge/argo-rollouts/echo/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-edge/argo-rollouts/echo/homer-app/localhost/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-edge/argo-rollouts/rollouts-demo/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-edge/argo-rollouts/rollouts-demo/homer-app/glootest.com/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-edge/argo-rollouts/rollouts-demo/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-edge/argo-rollouts/rollouts-demo/homer-app/localhost/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-edge/httpbin-bookinfo/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-edge/httpbin-bookinfo/homer-app/glootest.com/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-edge/httpbin-bookinfo/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-edge/httpbin-bookinfo/homer-app/localhost/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/bookinfo/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/bookinfo/homer-app/glootest.com/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/bookinfo/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-gateway/bookinfo/homer-app/localhost/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/bookinfo/homer-app/localhost/test.sh
+++ b/environments/gloo-gateway/bookinfo/homer-app/localhost/test.sh
@@ -9,7 +9,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"

--- a/environments/gloo-gateway/bookinfo/homer-app/test.sh
+++ b/environments/gloo-gateway/bookinfo/homer-app/test.sh
@@ -9,7 +9,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"

--- a/environments/gloo-gateway/core/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-gateway/core/homer-app/base/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/core/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/core/homer-app/glootest.com/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/core/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-gateway/core/homer-app/lb-discovery/init.sh
@@ -43,9 +43,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -117,7 +117,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/core/homer-app/lb-discovery/test.sh
+++ b/environments/gloo-gateway/core/homer-app/lb-discovery/test.sh
@@ -9,7 +9,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"

--- a/environments/gloo-gateway/core/homer-app/localhost/test.sh
+++ b/environments/gloo-gateway/core/homer-app/localhost/test.sh
@@ -9,7 +9,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"

--- a/environments/gloo-gateway/httpbin/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/httpbin/homer-app/glootest.com/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/httpbin/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-gateway/httpbin/homer-app/localhost/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/httpbin/homer-app/localhost/test.sh
+++ b/environments/gloo-gateway/httpbin/homer-app/localhost/test.sh
@@ -9,7 +9,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"

--- a/environments/gloo-gateway/int-ext-portal/homer-app/homer-portal.yaml
+++ b/environments/gloo-gateway/int-ext-portal/homer-app/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/int-ext-portal/homer-app/test.sh
+++ b/environments/gloo-gateway/int-ext-portal/homer-app/test.sh
@@ -9,7 +9,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"

--- a/environments/gloo-gateway/onlineboutique/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/onlineboutique/homer-app/glootest.com/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/onlineboutique/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-gateway/onlineboutique/homer-app/lb-discovery/init.sh
@@ -43,9 +43,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -117,7 +117,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/onlineboutique/homer-app/lb-discovery/test.sh
+++ b/environments/gloo-gateway/onlineboutique/homer-app/lb-discovery/test.sh
@@ -9,7 +9,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"

--- a/environments/gloo-gateway/onlineboutique/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-gateway/onlineboutique/homer-app/localhost/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/onlineboutique/homer-app/localhost/test.sh
+++ b/environments/gloo-gateway/onlineboutique/homer-app/localhost/test.sh
@@ -9,7 +9,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"

--- a/environments/gloo-gateway/onlineboutique/homer-app/tracing/homer-portal.yaml
+++ b/environments/gloo-gateway/onlineboutique/homer-app/tracing/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/glootest.com/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/lb-discovery/init.sh
@@ -43,9 +43,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -117,7 +117,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/lb-discovery/test.sh
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/lb-discovery/test.sh
@@ -9,7 +9,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/localhost/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/localhost/test.sh
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/localhost/test.sh
@@ -9,9 +9,9 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
-echo "https://github.com/solo-io/aoa-catalog/tree/main/environments/gloo-gateway/single-cluster-bookinfo#application-description"
+echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"
 echo
 echo

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-config/test.sh
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-config/test.sh
@@ -7,7 +7,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments/gloo-gateway/single-cluster-bookinfo#application-description"

--- a/environments/gloo-gateway/solowallet/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/solowallet/homer-app/glootest.com/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/solowallet/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-gateway/solowallet/homer-app/lb-discovery/init.sh
@@ -43,9 +43,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -117,7 +117,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/solowallet/homer-app/lb-discovery/test.sh
+++ b/environments/gloo-gateway/solowallet/homer-app/lb-discovery/test.sh
@@ -9,7 +9,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"

--- a/environments/gloo-gateway/solowallet/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-gateway/solowallet/homer-app/localhost/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-gateway/solowallet/homer-app/localhost/test.sh
+++ b/environments/gloo-gateway/solowallet/homer-app/localhost/test.sh
@@ -9,7 +9,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"

--- a/environments/gloo-gateway/solowallet/homer-config/test.sh
+++ b/environments/gloo-gateway/solowallet/homer-config/test.sh
@@ -7,7 +7,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-gateways --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"

--- a/environments/gloo-platform/core/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/core/mgmt/homer-app/base/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-platform/core/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/core/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/base/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/base/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/base/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-platform/multicluster-portal-k3d/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-portal-k3d/mgmt/homer-app/base/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/gloo-platform/multicluster-portal-k3d/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-portal-k3d/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/istio/ambient-demo/homer/base/homer-portal.yaml
+++ b/environments/istio/ambient-demo/homer/base/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/istio/ambient-demo/homer/init.sh
+++ b/environments/istio/ambient-demo/homer/init.sh
@@ -45,9 +45,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -120,7 +120,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/istio/ambient-demo/homer/test.sh
+++ b/environments/istio/ambient-demo/homer/test.sh
@@ -7,7 +7,7 @@ echo "Installation complete:"
 echo "A homepage has been exposed at the Istio Gateway wildcard '*' host to simplify navigation"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl -n istio-system --context ${cluster_context} get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-system --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"

--- a/environments/istio/basic-demo/homer/base/homer-portal.yaml
+++ b/environments/istio/basic-demo/homer/base/homer-portal.yaml
@@ -28,9 +28,9 @@ spec:
         
         image:
           # -- image repository
-          repository: b4bz/homer
+          repository: ably77/homer
           # -- image tag
-          tag: v23.05.1
+          tag: 0.1.0
           # -- image pull policy
           pullPolicy: IfNotPresent
         
@@ -103,7 +103,7 @@ spec:
                 
                 title: "aoa-catalog demo dashboard"
                 subtitle: "Homepage"
-                logo: "logo.png"
+                logo: "solo/glooy.png"
                 # icon: "fas fa-skull-crossbones" # Optional icon
                 
                 header: true

--- a/environments/istio/basic-demo/homer/test.sh
+++ b/environments/istio/basic-demo/homer/test.sh
@@ -9,7 +9,7 @@ echo "if running locally with K3d:"
 echo "access the dashboard at https://localhost/solo"
 echo
 echo "If using LoadBalancer External-IP:"
-echo "access the dashboard at https://$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].*}')/solo"
+echo "access the dashboard at https://$(kubectl --context ${cluster_context} get svc -n istio-system --selector=istio=ingressgateway -o jsonpath='{.items[*].status.loadBalancer.ingress[0].*}')/solo"
 echo
 echo "Additional details on hostname entries for this demo environment will be provided in the Welcome section, but is also described in the README section below:"
 echo "https://github.com/solo-io/aoa-catalog/tree/main/environments"


### PR DESCRIPTION
0.1.14 (12-27-23)
---
- update homer image to ably77/homer:0.1.0 (adds glooy logo)
- add --context to homer output command:
```
echo "access the dashboard at https://$(kubectl --context ${cluster_context} -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')/solo"
```