### PR TITLE
see changelog (0.1.16)

### DIFF
--- a/aoa-tools/tools/colima-install.sh
+++ b/aoa-tools/tools/colima-install.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${1:-} = "-h" || ${1:-} = "--help" ]]; then
+	echo "Starts Colima and K3s"
+	echo ""
+	echo "Usage: colima delete --force && $0"
+fi
+
+# new
+colima start --cpu 6 --memory 16 \
+  --vm-type=vz \
+  --kubernetes \
+  --network-address \
+  --k3s-arg "--disable=traefik"
+
+# Setup colima for ssh capability
+printf "=== Installing socat\n"
+colima ssh -- sudo apt install -y socat
+
+# Add node labels
+kubectl label nodes colima topology.kubernetes.io/region=us-west
+kubectl label nodes colima topology.kubernetes.io/zone=us-west-1
+
+# change context
+kubectl config rename-context colima ${cluster_context}


### PR DESCRIPTION
0.1.16 (date)
---
- add colima install script at `aoa-tools/tools/colima-install.sh`
- add colima as an additional infra option for local deployments. an additional --colima flag can be used in conjunction with -i in order to deploy colima + k3s instead of k3d + docker.
- rename `install_infra` function in `deploy.sh` to `install_k3d`
- fixed destroy function to destroy both colima and k3d options