### PR TITLE
see CHANGELOG (0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+0.3.3 (5-21-24)
+---
+- update helloworld-rollout example in gloo-gateway/progressive-delivery-argo-rollouts to use parent/child delegate route tables
+
 0.3.2 (5-21-24)
 ---
 - update ArgoCD to 2.10.10

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/helloworld-rollout/base/helloworld-rollout.yaml
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/helloworld-rollout/base/helloworld-rollout.yaml
@@ -83,14 +83,18 @@ spec:
         plugins:
           solo-io/glooplatform:
             routeTableSelector:
+              # Selects tables based on labels
               labels:
-                app: helloworld
+                routetable: helloworld
               namespace: helloworld
-              # name: helloworld-rt-443
+              # Selects tables based on name
+              # name: helloworld-delegate
               # namespace: helloworld
             routeSelector:
+              # Selects routes based on labels
               labels:
                 route: helloworld
+              # Selects routes based on name
               # name: helloworld
       steps:
       - setWeight: 10

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/helloworld-rollout/base/helloworld-rt-443.yaml
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/helloworld-rollout/base/helloworld-rt-443.yaml
@@ -1,10 +1,8 @@
 apiVersion: networking.gloo.solo.io/v2
 kind: RouteTable
 metadata:
-  name: helloworld-rt-443
+  name: helloworld-root
   namespace: helloworld
-  labels:
-    app: helloworld
 spec:
   hosts:
     - '*'
@@ -12,6 +10,27 @@ spec:
     - name: mgmt-north-south-gw-443
       namespace: istio-gateways
       cluster: mgmt
+  workloadSelectors: []
+  http:
+  - name: helloworld-delegate
+    delegate:
+      routeTables:
+        # Selects tables based on name
+        - name: helloworld-delegate
+          namespace: helloworld
+        # Selects tables based on labels
+        #- labels:
+        #    routetable: helloworld
+      sortMethod: ROUTE_SPECIFICITY
+---
+apiVersion: networking.gloo.solo.io/v2
+kind: RouteTable
+metadata:
+  name: helloworld-delegate
+  namespace: helloworld
+  labels:
+    routetable: helloworld
+spec:
   http:
     - name: helloworld
       matchers:


### PR DESCRIPTION
0.3.3 (5-21-24)
---
- update helloworld-rollout example in gloo-gateway/progressive-delivery-argo-rollouts to use parent/child delegate route tables