### PR TITLE
see CHANGELOG (0.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+0.3.4 (5-30-24)
+---
+- update gloo-edge/gatweay-api to 1.17.0-beta3
+
 0.3.3 (5-21-24)
 ---
 - update helloworld-rollout example in gloo-gateway/progressive-delivery-argo-rollouts to use parent/child delegate route tables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 0.3.4 (5-30-24)
 ---
 - update gloo-edge/gatweay-api to 1.17.0-beta3
-- set tools/colima-install.sh to use qemu instead of vz
 
 0.3.3 (5-21-24)
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 0.3.4 (5-30-24)
 ---
 - update gloo-edge/gatweay-api to 1.17.0-beta3
+- pin colima to v1.29.5+k3s1
 
 0.3.3 (5-21-24)
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ---
 - update gloo-edge/gatweay-api to 1.17.0-beta3
 - pin colima to v1.29.5+k3s1
+- set domain-qualified `/solo-io` finalizer name `resources-finalizer.argocd.argoproj.io/solo-io` to ArgoCD Applications
+    - Fixes this warning: 
+    ```
+    Warning: metadata.finalizers: "resources-finalizer.argocd.argoproj.io": prefer a domain-qualified finalizer name to avoid accidental conflicts with other finalizer writers
+    ```
 
 0.3.3 (5-21-24)
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 0.3.4 (5-30-24)
 ---
 - update gloo-edge/gatweay-api to 1.17.0-beta3
+- set tools/colima-install.sh to use qemu instead of vz
 
 0.3.3 (5-21-24)
 ---

--- a/aoa-tools/tools/colima-install.sh
+++ b/aoa-tools/tools/colima-install.sh
@@ -9,7 +9,7 @@ fi
 
 # new
 colima start --cpu 6 --memory 16 \
-  --vm-type=vz \
+  --vm-type=qemu \
   --kubernetes \
   --network-address \
   --k3s-arg "--disable=traefik"

--- a/aoa-tools/tools/colima-install.sh
+++ b/aoa-tools/tools/colima-install.sh
@@ -11,6 +11,7 @@ fi
 colima start --cpu 6 --memory 16 \
   --vm-type=vz \
   --kubernetes \
+  --kubernetes-version v1.29.5+k3s1 \
   --network-address \
   --k3s-arg "--disable=traefik"
 

--- a/aoa-tools/tools/colima-install.sh
+++ b/aoa-tools/tools/colima-install.sh
@@ -9,7 +9,7 @@ fi
 
 # new
 colima start --cpu 6 --memory 16 \
-  --vm-type=qemu \
+  --vm-type=vz \
   --kubernetes \
   --network-address \
   --k3s-arg "--disable=traefik"

--- a/aoa-tools/tools/configure-wave.sh
+++ b/aoa-tools/tools/configure-wave.sh
@@ -39,7 +39,7 @@ metadata:
   name: wave-${wave_name}-aoa
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   project: app-of-apps
   source:

--- a/environments/gloo-edge/argo-rollouts/echo/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-edge/argo-rollouts/echo/homer-app/localhost/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-edge/argo-rollouts/rollouts-demo/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-edge/argo-rollouts/rollouts-demo/homer-app/glootest.com/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-edge/argo-rollouts/rollouts-demo/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-edge/argo-rollouts/rollouts-demo/homer-app/localhost/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-edge/flagger-podinfo/flagger/base/flagger.yaml
+++ b/environments/gloo-edge/flagger-podinfo/flagger/base/flagger.yaml
@@ -4,7 +4,7 @@ metadata:
   name: flagger
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     namespace: gloo-system

--- a/environments/gloo-edge/gateway-api/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-edge/gateway-api/homer-app/glootest.com/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-edge/httpbin-bookinfo/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-edge/httpbin-bookinfo/homer-app/glootest.com/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-edge/httpbin-bookinfo/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-edge/httpbin-bookinfo/homer-app/localhost/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-edge/shared-components/gloo-edge-app/ee/gateway-api/gloo-edge-ee.yaml
+++ b/environments/gloo-edge/shared-components/gloo-edge-app/ee/gateway-api/gloo-edge-ee.yaml
@@ -94,7 +94,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.17.0-beta2
+    targetRevision: 1.17.0-beta3
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-edge/shared-components/gloo-edge-app/ee/gateway-api/gloo-edge-ee.yaml
+++ b/environments/gloo-edge/shared-components/gloo-edge-app/ee/gateway-api/gloo-edge-ee.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gloo-edge-enterprise-helm
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     namespace: gloo-system

--- a/environments/gloo-edge/shared-components/gloo-edge-app/ee/gloo-edge-ee.yaml
+++ b/environments/gloo-edge/shared-components/gloo-edge-app/ee/gloo-edge-ee.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gloo-edge-enterprise-helm
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     namespace: gloo-system

--- a/environments/gloo-edge/shared-components/gloo-edge-app/oss/gloo-edge-oss.yaml
+++ b/environments/gloo-edge/shared-components/gloo-edge-app/oss/gloo-edge-oss.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gloo-edge-oss
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     namespace: gloo-system

--- a/environments/gloo-gateway/bookinfo/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/bookinfo/homer-app/glootest.com/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/bookinfo/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-gateway/bookinfo/homer-app/localhost/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/core/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-gateway/core/gloo-platform/base/gloo-platform-helm.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gloo-platform-helm
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/core/gloo-platform/portal/gloo-platform-portal.yaml
+++ b/environments/gloo-gateway/core/gloo-platform/portal/gloo-platform-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gloo-platform-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/core/gloo-platform/tracing/gloo-platform-helm.yaml
+++ b/environments/gloo-gateway/core/gloo-platform/tracing/gloo-platform-helm.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gloo-platform-helm
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/core/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-gateway/core/homer-app/base/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/core/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/core/homer-app/glootest.com/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/core/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-gateway/core/homer-app/lb-discovery/init.sh
@@ -19,7 +19,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/core/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-gateway/core/istio/helm/base/istio-base.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-base
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-3"
 spec:

--- a/environments/gloo-gateway/core/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-gateway/core/istio/helm/base/istio-ingressgateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-ingressgateway
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:

--- a/environments/gloo-gateway/core/istio/helm/base/istiod.yaml
+++ b/environments/gloo-gateway/core/istio/helm/base/istiod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istiod
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:

--- a/environments/gloo-gateway/core/istio/helm/tracing/istio-base.yaml
+++ b/environments/gloo-gateway/core/istio/helm/tracing/istio-base.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-base
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-3"
 spec:

--- a/environments/gloo-gateway/core/istio/helm/tracing/istio-ingressgateway.yaml
+++ b/environments/gloo-gateway/core/istio/helm/tracing/istio-ingressgateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-ingressgateway
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:

--- a/environments/gloo-gateway/core/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-gateway/core/istio/helm/tracing/istiod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istiod
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:

--- a/environments/gloo-gateway/httpbin/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/httpbin/homer-app/glootest.com/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/httpbin/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-gateway/httpbin/homer-app/localhost/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/int-ext-portal/homer-app/homer-portal.yaml
+++ b/environments/gloo-gateway/int-ext-portal/homer-app/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/onlineboutique/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/onlineboutique/homer-app/glootest.com/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/onlineboutique/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-gateway/onlineboutique/homer-app/lb-discovery/init.sh
@@ -19,7 +19,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/onlineboutique/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-gateway/onlineboutique/homer-app/localhost/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/onlineboutique/homer-app/tracing/homer-portal.yaml
+++ b/environments/gloo-gateway/onlineboutique/homer-app/tracing/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/glootest.com/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/lb-discovery/init.sh
@@ -19,7 +19,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/localhost/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/solowallet/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/solowallet/homer-app/glootest.com/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/solowallet/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-gateway/solowallet/homer-app/lb-discovery/init.sh
@@ -19,7 +19,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-gateway/solowallet/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-gateway/solowallet/homer-app/localhost/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-mesh-core/additional-cluster-1/gloo-agent/init.sh
+++ b/environments/gloo-mesh-core/additional-cluster-1/gloo-agent/init.sh
@@ -84,7 +84,7 @@ metadata:
   name: gloo-platform-helm
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc
@@ -134,7 +134,7 @@ metadata:
   name: gloo-platform-otel-collector
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-mesh-core/additional-cluster-1/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/homer-app/base/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-mesh-core/additional-cluster-1/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-mesh-core/additional-cluster-1/homer-app/lb-discovery/init.sh
@@ -19,7 +19,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-base.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-base
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-3"
 spec:

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-ingressgateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-ingressgateway
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istiod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istiod
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:

--- a/environments/gloo-mesh-core/additional-cluster-2/gloo-agent/init.sh
+++ b/environments/gloo-mesh-core/additional-cluster-2/gloo-agent/init.sh
@@ -84,7 +84,7 @@ metadata:
   name: gloo-platform-helm
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc
@@ -134,7 +134,7 @@ metadata:
   name: gloo-platform-otel-collector
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-mesh-core/additional-cluster-2/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/homer-app/base/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-mesh-core/additional-cluster-2/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-mesh-core/additional-cluster-2/homer-app/lb-discovery/init.sh
@@ -19,7 +19,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-base.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-base
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-3"
 spec:

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-ingressgateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-ingressgateway
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istiod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istiod
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:

--- a/environments/gloo-mesh-core/singlecluster/gloo-mesh-core/base/gloo-platform-helm.yaml
+++ b/environments/gloo-mesh-core/singlecluster/gloo-mesh-core/base/gloo-platform-helm.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gloo-platform-helm
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-mesh-core/singlecluster/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-mesh-core/singlecluster/homer-app/base/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-mesh-core/singlecluster/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-mesh-core/singlecluster/homer-app/lb-discovery/init.sh
@@ -19,7 +19,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-base.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-base
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-3"
 spec:

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-ingressgateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-ingressgateway
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/istiod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istiod
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:

--- a/environments/gloo-platform/core/cluster1/gloo-platform/base/gloo-platform-addons.yaml
+++ b/environments/gloo-platform/core/cluster1/gloo-platform/base/gloo-platform-addons.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gloo-platform-addons
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-platform/core/cluster1/gloo-platform/init.sh
+++ b/environments/gloo-platform/core/cluster1/gloo-platform/init.sh
@@ -45,7 +45,7 @@ metadata:
   name: gloo-platform-helm
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc
@@ -94,7 +94,7 @@ metadata:
   name: gloo-platform-otel-collector
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-platform/core/cluster1/gloo-platform/portal/gloo-platform-addons.yaml
+++ b/environments/gloo-platform/core/cluster1/gloo-platform/portal/gloo-platform-addons.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gloo-platform-addons
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-platform/core/cluster1/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/base/istio-eastwestgateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-eastwestgateway
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 spec:

--- a/environments/gloo-platform/core/cluster1/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/base/istiod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istiod
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:

--- a/environments/gloo-platform/core/cluster1/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/tracing/istiod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istiod
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:

--- a/environments/gloo-platform/core/cluster2/gloo-platform/init.sh
+++ b/environments/gloo-platform/core/cluster2/gloo-platform/init.sh
@@ -45,7 +45,7 @@ metadata:
   name: gloo-platform-helm
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc
@@ -94,7 +94,7 @@ metadata:
   name: gloo-platform-otel-collector
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-platform/core/cluster2/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/helm/base/istio-eastwestgateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-eastwestgateway
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 spec:

--- a/environments/gloo-platform/core/cluster2/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/helm/base/istiod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istiod
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:

--- a/environments/gloo-platform/core/cluster2/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/helm/tracing/istiod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istiod
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:

--- a/environments/gloo-platform/core/mgmt/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-platform/core/mgmt/gloo-platform/base/gloo-platform-helm.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gloo-platform-helm
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-platform/core/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/core/mgmt/homer-app/base/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-platform/core/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/core/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/istio-ingressgateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-ingressgateway
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/istiod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istiod
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:

--- a/environments/gloo-platform/core/mgmt/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/tracing/istiod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istiod
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/istio-base.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-base
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-3"
 spec:

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/istio-ingressgateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-ingressgateway
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/istiod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istiod
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:

--- a/environments/gloo-platform/core/shared-components/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/tracing/istiod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istiod
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/base/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/base/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/base/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/gloo-portal/solo-dev-portal/gloo-edge-app/base/gloo-edge-ee-nofed.yaml
+++ b/environments/gloo-portal/solo-dev-portal/gloo-edge-app/base/gloo-edge-ee-nofed.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gloo-edge-enterprise-helm
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     namespace: gloo-system

--- a/environments/gloo-portal/solo-dev-portal/gloo-portal-app/base/gloo-portal-helm.yaml
+++ b/environments/gloo-portal/solo-dev-portal/gloo-portal-app/base/gloo-portal-helm.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gloo-portal-helm
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     namespace: gloo-portal

--- a/environments/istio/ambient-demo/core/homer/init.sh
+++ b/environments/istio/ambient-demo/core/homer/init.sh
@@ -21,7 +21,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-base.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-base.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-base
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-4"
 spec:

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-cni.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-cni.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-cni
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-3"
 spec:

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-ingressgateway.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-ingressgateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-ingressgateway
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-ztunnel.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-ztunnel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-ztunnel
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:

--- a/environments/istio/ambient-demo/core/istio/ambient/istiod.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istiod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istiod
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-3"
 spec:

--- a/environments/istio/ambient-demo/core/istio/gke/istio-cni.yaml
+++ b/environments/istio/ambient-demo/core/istio/gke/istio-cni.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-cni
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-3"
 spec:

--- a/environments/istio/ambient-demo/core/istio/gke/istio-ztunnel.yaml
+++ b/environments/istio/ambient-demo/core/istio/gke/istio-ztunnel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-ztunnel
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:

--- a/environments/istio/ambient-demo/gke/homer/init.sh
+++ b/environments/istio/ambient-demo/gke/homer/init.sh
@@ -21,7 +21,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/istio/ambient-demo/random-generated-apps/homer/init.sh
+++ b/environments/istio/ambient-demo/random-generated-apps/homer/init.sh
@@ -21,7 +21,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/istio/ambient-demo/uniform-apps/homer/init.sh
+++ b/environments/istio/ambient-demo/uniform-apps/homer/init.sh
@@ -21,7 +21,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/istio/basic-demo/homer/base/homer-portal.yaml
+++ b/environments/istio/basic-demo/homer/base/homer-portal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/istio/basic-demo/homer/lb-discovery/init.sh
+++ b/environments/istio/basic-demo/homer/lb-discovery/init.sh
@@ -19,7 +19,7 @@ metadata:
   name: homer-portal
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
 spec:
   destination:
     server: https://kubernetes.default.svc

--- a/environments/istio/basic-demo/istio/base/istio-base.yaml
+++ b/environments/istio/basic-demo/istio/base/istio-base.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-base
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-3"
 spec:

--- a/environments/istio/basic-demo/istio/base/istio-ingressgateway.yaml
+++ b/environments/istio/basic-demo/istio/base/istio-ingressgateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-ingressgateway
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:

--- a/environments/istio/basic-demo/istio/base/istiod.yaml
+++ b/environments/istio/basic-demo/istio/base/istiod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istiod
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/solo-io
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:


### PR DESCRIPTION
0.3.4 (5-30-24)
---
- update gloo-edge/gatweay-api to 1.17.0-beta3
- pin colima to v1.29.5+k3s1
- set domain-qualified `/solo-io` finalizer name `resources-finalizer.argocd.argoproj.io/solo-io` to ArgoCD Applications
    - Fixes this warning: 
    ```
    Warning: metadata.finalizers: "resources-finalizer.argocd.argoproj.io": prefer a domain-qualified finalizer name to avoid accidental conflicts with other finalizer writers
    ```