### PR TITLE
see CHANGELOG (0.3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+0.3.7 (6-6-24)
+---
+- update root trust to be shared across all clusters
+- add e/w gateway to mgmt cluster by default in all gloo-platform environments
+- remove gloo-mesh-ui from the mesh in gloo-platform environments
+- add httpbin app to mgmt cluster in gloo-platform/multicluster-bookinfo-httpbin environment
+    - this allows us to demo priority failover by region when using labels such as `topology.kubernetes.io/region` set on the nodes
+    - when using `-i` flag to install locally, the k3d config is labeled with the following mgmt (us-west), cluster1 (us-central), cluster2 (us-east)
+- update httpbin VirtualDestination to select all workload clusters and apply `failover: "true"` label
+- add FailoverPolicy and OutlierDetectionPolicy to httpbin app in gloo-platform/multicluster-bookinfo-httpbin environment. The localityMappings are configured to show the following:
+    - from us-central, prioritize failover to us-east first then us-west
+    - from us-east, prioritize failover to us-central first then us-west
+
 0.3.6 (6-6-24)
 ---
 - enable okta extauth for httpbin app in gloo-edge/gateway-api environment

--- a/environments/gloo-gateway/core/gloo-platform-config/base/gloo-mesh-mgmt-kubernetescluster.yaml
+++ b/environments/gloo-gateway/core/gloo-platform-config/base/gloo-mesh-mgmt-kubernetescluster.yaml
@@ -3,7 +3,5 @@ kind: KubernetesCluster
 metadata:
   name: mgmt
   namespace: gloo-mesh
-  labels:
-    roottrust: notshared
 spec:
   clusterDomain: cluster.local

--- a/environments/gloo-gateway/core/gloo-platform-config/base/roottrustpolicy-generated.yaml
+++ b/environments/gloo-gateway/core/gloo-platform-config/base/roottrustpolicy-generated.yaml
@@ -4,10 +4,6 @@ metadata:
   name: root-trust-policy
   namespace: gloo-mesh
 spec:
-  applyToMeshes:
-  - istio:
-      clusterSelector:
-        roottrust: shared
   config:
     autoRestartPods: true
     mgmtServerCa:

--- a/environments/gloo-gateway/core/gloo-platform-config/base/roottrustpolicy-secretref.yaml
+++ b/environments/gloo-gateway/core/gloo-platform-config/base/roottrustpolicy-secretref.yaml
@@ -4,10 +4,6 @@ metadata:
   name: root-trust-policy
   namespace: gloo-mesh
 spec:
-  applyToMeshes:
-  - istio:
-      clusterSelector:
-        roottrust: shared
   config:
     autoRestartPods: true
     mgmtServerCa:

--- a/environments/gloo-gateway/core/gloo-platform-config/glootest.com/gloo-mesh-mgmt-kubernetescluster.yaml
+++ b/environments/gloo-gateway/core/gloo-platform-config/glootest.com/gloo-mesh-mgmt-kubernetescluster.yaml
@@ -3,7 +3,5 @@ kind: KubernetesCluster
 metadata:
   name: mgmt
   namespace: gloo-mesh
-  labels:
-    roottrust: notshared
 spec:
   clusterDomain: cluster.local

--- a/environments/gloo-gateway/core/gloo-platform-config/glootest.com/roottrustpolicy-generated.yaml
+++ b/environments/gloo-gateway/core/gloo-platform-config/glootest.com/roottrustpolicy-generated.yaml
@@ -4,10 +4,6 @@ metadata:
   name: root-trust-policy
   namespace: gloo-mesh
 spec:
-  applyToMeshes:
-  - istio:
-      clusterSelector:
-        roottrust: shared
   config:
     autoRestartPods: true
     mgmtServerCa:

--- a/environments/gloo-gateway/core/gloo-platform-config/glootest.com/roottrustpolicy-secretref.yaml
+++ b/environments/gloo-gateway/core/gloo-platform-config/glootest.com/roottrustpolicy-secretref.yaml
@@ -4,10 +4,6 @@ metadata:
   name: root-trust-policy
   namespace: gloo-mesh
 spec:
-  applyToMeshes:
-  - istio:
-      clusterSelector:
-        roottrust: shared
   config:
     autoRestartPods: true
     mgmtServerCa:

--- a/environments/gloo-gateway/core/gloo-platform-config/tracing/gloo-mesh-mgmt-kubernetescluster.yaml
+++ b/environments/gloo-gateway/core/gloo-platform-config/tracing/gloo-mesh-mgmt-kubernetescluster.yaml
@@ -3,7 +3,5 @@ kind: KubernetesCluster
 metadata:
   name: mgmt
   namespace: gloo-mesh
-  labels:
-    roottrust: notshared
 spec:
   clusterDomain: cluster.local

--- a/environments/gloo-gateway/core/gloo-platform-config/tracing/roottrustpolicy-generated.yaml
+++ b/environments/gloo-gateway/core/gloo-platform-config/tracing/roottrustpolicy-generated.yaml
@@ -4,10 +4,6 @@ metadata:
   name: root-trust-policy
   namespace: gloo-mesh
 spec:
-  applyToMeshes:
-  - istio:
-      clusterSelector:
-        roottrust: shared
   config:
     autoRestartPods: true
     mgmtServerCa:

--- a/environments/gloo-gateway/core/gloo-platform-config/tracing/roottrustpolicy-secretref.yaml
+++ b/environments/gloo-gateway/core/gloo-platform-config/tracing/roottrustpolicy-secretref.yaml
@@ -4,10 +4,6 @@ metadata:
   name: root-trust-policy
   namespace: gloo-mesh
 spec:
-  applyToMeshes:
-  - istio:
-      clusterSelector:
-        roottrust: shared
   config:
     autoRestartPods: true
     mgmtServerCa:

--- a/environments/gloo-platform/core/mgmt/gloo-platform-config/base/gloo-mesh-mgmt-kubernetescluster.yaml
+++ b/environments/gloo-platform/core/mgmt/gloo-platform-config/base/gloo-mesh-mgmt-kubernetescluster.yaml
@@ -3,7 +3,5 @@ kind: KubernetesCluster
 metadata:
   name: mgmt
   namespace: gloo-mesh
-  labels:
-    roottrust: notshared
 spec:
   clusterDomain: cluster.local

--- a/environments/gloo-platform/core/mgmt/gloo-platform-config/base/roottrustpolicy-generated.yaml
+++ b/environments/gloo-platform/core/mgmt/gloo-platform-config/base/roottrustpolicy-generated.yaml
@@ -4,10 +4,6 @@ metadata:
   name: root-trust-policy
   namespace: gloo-mesh
 spec:
-  applyToMeshes:
-  - istio:
-      clusterSelector:
-        roottrust: shared
   config:
     autoRestartPods: true
     mgmtServerCa:

--- a/environments/gloo-platform/core/mgmt/gloo-platform-config/base/roottrustpolicy-secretref.yaml
+++ b/environments/gloo-platform/core/mgmt/gloo-platform-config/base/roottrustpolicy-secretref.yaml
@@ -4,10 +4,6 @@ metadata:
   name: root-trust-policy
   namespace: gloo-mesh
 spec:
-  applyToMeshes:
-  - istio:
-      clusterSelector:
-        roottrust: shared
   config:
     autoRestartPods: true
     mgmtServerCa:

--- a/environments/gloo-platform/core/mgmt/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-platform/core/mgmt/gloo-platform/base/gloo-platform-helm.yaml
@@ -53,15 +53,15 @@ spec:
                     clientSecret: _MS9PJ52NpUJo8Hj2nE4zj90hX4BFkW61SdaXJfE
                     clientSecretName: dashboard
                     issuerUrl: https://dev-22653158.okta.com/oauth2/default
-            deploymentOverrides:
-                spec:
-                    template:
-                        metadata:
-                            annotations:
-                                proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
-                            labels:
-                                istio.io/rev: 1-22
-                                sidecar.istio.io/inject: "true"
+            #deploymentOverrides:
+            #    spec:
+            #        template:
+            #            metadata:
+            #                annotations:
+            #                    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+            #                labels:
+            #                    istio.io/rev: 1-22
+            #                    sidecar.istio.io/inject: "true"
             enabled: true
             serviceType: ClusterIP
         extAuthService:

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/istio-eastwestgateway.yaml
@@ -1,0 +1,62 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: istio-eastwestgateway
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io/solo-io
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: istio-gateways
+  project: default
+  source:
+    chart: gateway
+    repoURL: https://istio-release.storage.googleapis.com/charts
+    targetRevision: 1.22.0
+    helm:
+      values: |
+        # Name allows overriding the release name. Generally this should not be set
+        name: "istio-eastwestgateway"
+        # revision declares which revision this gateway is a part of
+        revision: "1-22"
+        
+        replicaCount: 1
+        
+        service:
+          # Type of service. Set to "None" to disable the service entirely
+          type: LoadBalancer
+          ports:
+          - name: tcp-status-port
+            port: 15021
+            targetPort: 15021
+          - name: tls
+            port: 15443
+            targetPort: 15443
+          - name: tcp-istiod
+            port: 15012
+            targetPort: 15012
+          - name: tcp-webhook
+            port: 15017
+            targetPort: 15017
+          annotations:
+            # AWS NLB Annotation
+            service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+          loadBalancerIP: ""
+          loadBalancerSourceRanges: []
+          externalTrafficPolicy: ""
+        
+        # Pod environment variables
+        env:
+          ISTIO_META_ROUTER_MODE: "sni-dnat"
+          ISTIO_META_REQUESTED_NETWORK_VIEW: "mgmt"
+        
+        # Labels to apply to all resources
+        labels:
+          istio.io/rev: 1-22
+          istio: eastwestgateway
+          topology.istio.io/network: mgmt
+  syncPolicy:
+    automated: {}

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/kustomization.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - certmanager-selfsigned-issuer.yaml
 - grafana-dashboard-configmaps
 - grafana-helm.yaml
+- istio-eastwestgateway.yaml
 
 patchesStrategicMerge:
 - istiod.yaml

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/catalog.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/catalog.yaml
@@ -44,6 +44,13 @@ waves:
       -  $env_path/bookinfo-config/init.sh
       post_deploy:
       -  $env_path/bookinfo-config/test.sh 
+  - name: httpbin-app
+    location: $env_path/httpbin-app/base
+    scripts:
+      pre_deploy: 
+      -  $env_path/httpbin-app/init.sh
+      post_deploy:
+      -  $env_path/httpbin-app/test.sh 
   - name: httpbin-config
     location: $env_path/httpbin-config/wildcard
     scripts:

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-app/base/httpbin-in-mesh.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-app/base/httpbin-in-mesh.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: in-mesh
+  namespace: httpbin
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: in-mesh
+  namespace: httpbin
+  labels:
+    app: in-mesh
+    service: in-mesh
+    version: v1
+spec:
+  ports:
+  - name: http
+    port: 8000
+    targetPort: 80
+  selector:
+    app: in-mesh
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: in-mesh
+  namespace: httpbin
+  labels:
+    version: v1
+    app: in-mesh
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: in-mesh
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: in-mesh
+        version: v1
+        istio.io/rev: 1-22
+      annotations:
+        proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+    spec:
+      serviceAccountName: in-mesh
+      containers:
+      - image: docker.io/kennethreitz/httpbin
+        imagePullPolicy: IfNotPresent
+        name: in-mesh
+        ports:
+        - containerPort: 80

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-app/base/kustomization.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-app/base/kustomization.yaml
@@ -1,0 +1,7 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# list of resources to be Applied
+resources:
+- httpbin-in-mesh.yaml

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-app/init.sh
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-app/init.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "wave description:"
+echo "deploy httpbin app"

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-app/test.sh
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-app/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# wait for completion of httpbin install
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment in-mesh httpbin 10 ${cluster_context}

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-config/base/httpbin-failoverpolicy.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-config/base/httpbin-failoverpolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: resilience.policy.gloo.solo.io/v2
+kind: FailoverPolicy
+metadata:
+  name: httpbin-failover
+  namespace: httpbin-team-config
+spec:
+  applyToDestinations:
+  - kind: VIRTUAL_DESTINATION
+    selector:
+      labels:
+        failover: "true"
+  config:
+    localityMappings:
+    # prioritize failover to us-east first then us-west
+    - from:
+        region: us-central
+      to:
+        - region: us-east
+        - region: us-west
+    # prioritize failover to us-central first then us-west
+    - from:
+        region: us-east
+      to:
+        - region: us-central
+        - region: us-west

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-config/base/httpbin-outlierdetectionpolicy.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-config/base/httpbin-outlierdetectionpolicy.yaml
@@ -1,0 +1,16 @@
+apiVersion: resilience.policy.gloo.solo.io/v2
+kind: OutlierDetectionPolicy
+metadata:
+  name: outlier-detection
+  namespace: httpbin-team-config
+spec:
+  applyToDestinations:
+  - kind: VIRTUAL_DESTINATION
+    selector:
+      labels:
+        failover: "true"
+  config:
+    baseEjectionTime: 30s
+    consecutiveErrors: 2
+    interval: 5s
+    maxEjectionPercent: 100

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-config/base/httpbin-vd.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-config/base/httpbin-vd.yaml
@@ -3,6 +3,8 @@ kind: VirtualDestination
 metadata:
   name: httpbin-vd
   namespace: httpbin
+  labels:
+    failover: "true"
 spec:
   hosts:
   - httpbin.randomvalue
@@ -10,11 +12,6 @@ spec:
   - namespace: httpbin
     labels:
       app: in-mesh
-    cluster: cluster1
-  - namespace: httpbin
-    labels:
-      app: in-mesh
-    cluster: cluster2
   ports:
     - number: 8000
       protocol: HTTP

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-config/base/kustomization.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-config/base/kustomization.yaml
@@ -9,3 +9,6 @@ resources:
 - httpbin-workspacesettings.yaml
 - httpbin-rt-443.yaml
 - httpbin-vd.yaml
+- httpbin-failoverpolicy.yaml
+- httpbin-outlierdetectionpolicy.yaml
+- httpbin-vd.yaml


### PR DESCRIPTION
0.3.7 (6-6-24)
---
- update root trust to be shared across all clusters
- add e/w gateway to mgmt cluster by default in all gloo-platform environments
- remove gloo-mesh-ui from the mesh in gloo-platform environments
- add httpbin app to mgmt cluster in gloo-platform/multicluster-bookinfo-httpbin environment
    - this allows us to demo priority failover by region when using labels such as `topology.kubernetes.io/region` set on the nodes
    - when using `-i` flag to install locally, the k3d config is labeled with the following mgmt (us-west), cluster1 (us-central), cluster2 (us-east)
- update httpbin VirtualDestination to select all workload clusters and apply `failover: "true"` label
- add FailoverPolicy and OutlierDetectionPolicy to httpbin app in gloo-platform/multicluster-bookinfo-httpbin environment. The localityMappings are configured to show the following:
    - from us-central, prioritize failover to us-east first then us-west
    - from us-east, prioritize failover to us-central first then us-west