### PR TITLE
see CHANGELOG (0.3.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 
+0.3.13 (7-8-24)
+---
+- Apply api-key auth to bookinfo example in gloo-edge/gateway-api
+- Add JWT virtualhostoption to gateway in gloo-edge/gateway-api (commented out to demonstrate manually)
+- Update homer portal in gloo-edge/gateway-api
+
 0.3.12 (7-5-24)
 ---
-- restructure environments/gloo-edge for easier portability between branches
+- restructure gloo-edge/gateway-api for easier portability between branches
 
 0.3.11 (7-5-24)
 ---
-- restructure environments/gloo-edge for easier portability between branches
+- restructure gloo-edge/gateway-api for easier portability between branches
 
 0.3.10 (7-5-24)
 ---

--- a/environments/gloo-edge/gateway-api/bookinfo-app/base/bookinfo-parent-route.yaml
+++ b/environments/gloo-edge/gateway-api/bookinfo-app/base/bookinfo-parent-route.yaml
@@ -22,10 +22,10 @@ spec:
         - path:
             type: PathPrefix
             value: /api/bookinfo
-      #filters:
-      #  - type: ExtensionRef
-      #    extensionRef:
-      #      group: gateway.solo.io
-      #      kind: RouteOption
-      #      name: bookinfo-route-policies
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.solo.io
+            kind: RouteOption
+            name: bookinfo-route-policies
     

--- a/environments/gloo-edge/gateway-api/bookinfo-app/base/bookinfo-route-policies.yaml
+++ b/environments/gloo-edge/gateway-api/bookinfo-app/base/bookinfo-route-policies.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.solo.io/v1
+kind: RouteOption
+metadata:
+  name: bookinfo-route-policies
+  namespace: bookinfo
+spec:
+  # extauth options specified at the per-route level 
+  options:
+    # api-key ext auth
+    extauth:
+      configRef:
+        name: apikey-auth
+        namespace: gloo-system   
+    

--- a/environments/gloo-edge/gateway-api/bookinfo-app/base/kustomization.yaml
+++ b/environments/gloo-edge/gateway-api/bookinfo-app/base/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 - bookinfo.yaml
 - bookinfo-parent-route.yaml
 - bookinfo-delegate-route.yaml
+- bookinfo-route-policies.yaml

--- a/environments/gloo-edge/gateway-api/gateway-api-config/base/api-key-auth.yaml
+++ b/environments/gloo-edge/gateway-api/gateway-api-config/base/api-key-auth.yaml
@@ -1,0 +1,13 @@
+apiVersion: enterprise.gloo.solo.io/v1
+kind: AuthConfig
+metadata:
+  name: apikey-auth
+  namespace: gloo-system
+spec:
+  configs:
+  - apiKeyAuth:
+      # This is the name of the header that is expected to contain the API key.
+      # This field is optional and defaults to `api-key` if not present.
+      headerName: bookinfo-key
+      labelSelector:
+        team: infrastructure

--- a/environments/gloo-edge/gateway-api/gateway-api-config/base/example-api-key.yaml
+++ b/environments/gloo-edge/gateway-api/gateway-api-config/base/example-api-key.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  api-key: TjJZd01ESXhaVEV0TkdVek5TMWpOemd6TFRSa1lqQXRZakUyWXpSa1pHVm1OamN5
+kind: Secret
+metadata:
+  labels:
+    team: infrastructure
+  name: infra-apikey
+  namespace: gloo-system
+type: extauth.solo.io/apikey

--- a/environments/gloo-edge/gateway-api/gateway-api-config/base/https-gateway-virtualhostoptions.yaml
+++ b/environments/gloo-edge/gateway-api/gateway-api-config/base/https-gateway-virtualhostoptions.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.solo.io/v1
+kind: VirtualHostOption
+metadata:
+  name: https-gateway-virtualhostoptions
+  namespace: gloo-system
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: https
+    namespace: gloo-system
+  options:
+    # jwt validation and claims to headers
+    jwt:
+      providers:
+        solo:
+          tokenSource:
+            headers:
+            - header: x-token
+            queryParams:
+            - token
+          claimsToHeaders:
+          - claim: org
+            header: x-company
+          issuer: solo.io
+          jwks:
+            local:
+              key: |
+                -----BEGIN PUBLIC KEY-----
+                MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6IA5LB7RG7eqoPyoP3GM
+                gWIdYKwIvYsekCHKf2Co3nCb7ii2kDsNNHJygTsHFO2v5Fqe0/z40A2Qtkf3GjKl
+                CnFJCoxWX22PZNqEC4b1g12xqZyv7AE8pqhLkp/EFfB1abZJtboIC1y280JVk+iK
+                iEYGYjC5/PxV3Ynk1QuqC+rcdu6XP6m76p/bzYygaBGVU6ekaDG5B3vheqOlAe/f
+                hq82aS9V0vjKZbob0uNJFB0diTgUVhFech+CN9lYX7ucUwA5OqRV7zpXTFzxo08c
+                K/WHCWcZX6TCsfcYHV90abTNl7v+n5JDJfxQJp4RKlVQ4CaEIKBwZtIj1dvbZ9wZ
+                gQIDAQAB
+                -----END PUBLIC KEY-----

--- a/environments/gloo-edge/gateway-api/gateway-api-config/base/kustomization.yaml
+++ b/environments/gloo-edge/gateway-api/gateway-api-config/base/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
 - argocd-https.yaml
 - upstream-tls.yaml
 - okta-client-secret.yaml
+- https-gateway-virtualhostoptions.yaml
+- api-key-auth.yaml

--- a/environments/gloo-edge/gateway-api/gateway-api-config/base/kustomization.yaml
+++ b/environments/gloo-edge/gateway-api/gateway-api-config/base/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
 - argocd-https.yaml
 - upstream-tls.yaml
 - okta-client-secret.yaml
-- https-gateway-virtualhostoptions.yaml
+#- https-gateway-virtualhostoptions.yaml
 - api-key-auth.yaml
+- example-api-key.yaml

--- a/environments/gloo-edge/gateway-api/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-edge/gateway-api/homer-app/base/homer-portal.yaml
@@ -157,6 +157,9 @@ spec:
                     Below are a few common usernames to explore the applications and portals:<br />
                     Username: jdoe@solo.io // Password: gloo-dev<br />
                     Username: jdoe@gmail.com // Password: gloo-public<br /><br />
+
+                    Used in API-Key auth example:<br />
+                    bookinfo-key: N2YwMDIxZTEtNGUzNS1jNzgzLTRkYjAtYjE2YzRkZGVmNjcy<br />
                 
                 # Optional navbar
                 # links: [] # Allows for navbar (dark mode, layout, and search) without any links
@@ -197,6 +200,7 @@ spec:
                         url: "https://httpbin.glootest.com"
                         target: "_blank" # optional html a tag target attribute
                       - name: "Bookinfo"
+                        subtitle: "requires bookinfo-key header"
                         icon: "fas fa-book-reader"
                         tag: "bookinfo"
                         url: "https://bookinfo.glootest.com/productpage"


### PR DESCRIPTION
0.3.13 (7-8-24)
---
- Apply api-key auth to bookinfo example in gloo-edge/gateway-api
- Add JWT virtualhostoption to gateway in gloo-edge/gateway-api (commented out to demonstrate manually)
- Update homer portal in gloo-edge/gateway-api