### PR TITLE
see CHANGELOG (0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+0.5.1 (8-19-24)
+---
+- update istio helm chart version to `1.23.0-solo` and revision label `1-23` across all environments
+
 0.5.0 (8-15-24)
 ---
 - update gloo-platform-helm chart across all environments to use 2.6.0

--- a/environments/gloo-edge/gateway-api/with-gm-istio/bookinfo-app/base/bookinfo-ns.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/bookinfo-app/base/bookinfo-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bookinfo
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-edge/gateway-api/with-gm-istio/client-app/base/in-mesh-client.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/client-app/base/in-mesh-client.yaml
@@ -34,7 +34,7 @@ spec:
     metadata:
       labels:
         name: in-mesh-client
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
     spec:
       serviceAccountName: in-mesh-client
       containers:

--- a/environments/gloo-edge/gateway-api/with-gm-istio/clusterconfig/base/gloo-mesh-addons-ns.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/clusterconfig/base/gloo-mesh-addons-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: gloo-mesh-addons
   #labels:
-  #  istio.io/rev: 1-22
+  #  istio.io/rev: 1-23

--- a/environments/gloo-edge/gateway-api/with-gm-istio/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -25,7 +25,7 @@ spec:
               glooGateway:
                 istio:
                   istioProxyContainer:
-                    istioDiscoveryAddress: istiod-1-22.istio-system.svc:15012
+                    istioDiscoveryAddress: istiod-1-23.istio-system.svc:15012
                     istioMetaClusterId: Kubernetes
                     istioMetaMeshId: Kubernetes
           gatewayProxies:

--- a/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform/base/gloo-platform-helm.yaml
@@ -64,7 +64,7 @@ spec:
             #                annotations:
             #                    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             #                labels:
-            #                    istio.io/rev: 1-22
+            #                    istio.io/rev: 1-23
             #                    sidecar.istio.io/inject: "true"
             enabled: true
             serviceType: ClusterIP

--- a/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform/base/mgmt-grafana.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform/base/mgmt-grafana.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-edge/gateway-api/with-gm-istio/httpbin-app/base/httpbin-ns.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/httpbin-app/base/httpbin-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: httpbin
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-edge/gateway-api/with-gm-istio/istio/base/istio-base.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/istio/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-edge/gateway-api/with-gm-istio/istio/base/istiod.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/istio/base/istiod.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
         global:
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           accessLogFile: /dev/stdout
           enableAutoMtls: true

--- a/environments/gloo-edge/gateway-api/with-gm-istio/istio/base/istiod.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/istio/base/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
           tag: 1.23.0-solo
@@ -40,6 +40,6 @@ spec:
   ignoreDifferences:
     - group: admissionregistration.k8s.io
       kind: ValidatingWebhookConfiguration
-      name: istio-validator-1-22-istio-system
+      name: istio-validator-1-23-istio-system
       jsonPointers:
         - /webhooks/0/failurePolicy

--- a/environments/gloo-edge/gateway-api/with-gm-istio/istio/base/kiali.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/istio/base/kiali.yaml
@@ -74,7 +74,7 @@ data:
       pod_annotations: {}
       pod_labels:
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       priority_class_name: ""
       replicas: 1
       resources:
@@ -116,9 +116,9 @@ data:
         url: http://prometheus:9090/prometheus
       ### add the following if using revisioned based istio installation
       istio:
-        config_map_name: istio-1-22
-        istio_sidecar_injector_config_map_name: istio-sidecar-injector-1-22
-        istiod_deployment_name: istiod-1-22
+        config_map_name: istio-1-23
+        istio_sidecar_injector_config_map_name: istio-sidecar-injector-1-23
+        istiod_deployment_name: istiod-1-23
         root_namespace: istio-system
     identity:
       cert_file: ""

--- a/environments/gloo-edge/gateway-api/with-gm-istio/istio/test.sh
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/istio/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istiod-1-22 istio-system 10 ${cluster_context}
-#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-22 istio-eastwest 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istiod-1-23 istio-system 10 ${cluster_context}
+#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-23 istio-eastwest 10 ${cluster_context}

--- a/environments/gloo-edge/gateway-api/with-istio-ambient/istio/ambient/istio-base.yaml
+++ b/environments/gloo-edge/gateway-api/with-istio-ambient/istio/ambient/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-edge/gateway-api/with-istio-ambient/istio/ambient/istio-cni.yaml
+++ b/environments/gloo-edge/gateway-api/with-istio-ambient/istio/ambient/istio-cni.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: cni
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         profile: ambient

--- a/environments/gloo-edge/gateway-api/with-istio-ambient/istio/ambient/istio-ingressgateway.yaml
+++ b/environments/gloo-edge/gateway-api/with-istio-ambient/istio/ambient/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-edge/gateway-api/with-istio-ambient/istio/ambient/istio-ztunnel.yaml
+++ b/environments/gloo-edge/gateway-api/with-istio-ambient/istio/ambient/istio-ztunnel.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: ztunnel
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-edge/gateway-api/with-istio-ambient/istio/ambient/istiod.yaml
+++ b/environments/gloo-edge/gateway-api/with-istio-ambient/istio/ambient/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         profile: ambient

--- a/environments/gloo-edge/gateway-api/with-istio-ambient/istio/gke/istio-cni.yaml
+++ b/environments/gloo-edge/gateway-api/with-istio-ambient/istio/gke/istio-cni.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: cni
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         profile: ambient

--- a/environments/gloo-edge/gateway-api/with-istio-ambient/istio/gke/istio-ztunnel.yaml
+++ b/environments/gloo-edge/gateway-api/with-istio-ambient/istio/gke/istio-ztunnel.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: ztunnel
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-edge/gateway-api/with-istio-sidecar/bookinfo-app/base/bookinfo-ns.yaml
+++ b/environments/gloo-edge/gateway-api/with-istio-sidecar/bookinfo-app/base/bookinfo-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bookinfo
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-edge/gateway-api/with-istio-sidecar/client-app/base/in-mesh-client.yaml
+++ b/environments/gloo-edge/gateway-api/with-istio-sidecar/client-app/base/in-mesh-client.yaml
@@ -34,7 +34,7 @@ spec:
     metadata:
       labels:
         name: in-mesh-client
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
     spec:
       serviceAccountName: in-mesh-client
       containers:

--- a/environments/gloo-edge/gateway-api/with-istio-sidecar/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-edge/gateway-api/with-istio-sidecar/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -25,7 +25,7 @@ spec:
               glooGateway:
                 istio:
                   istioProxyContainer:
-                    istioDiscoveryAddress: istiod-1-22.istio-system.svc:15012
+                    istioDiscoveryAddress: istiod-1-23.istio-system.svc:15012
                     istioMetaClusterId: Kubernetes
                     istioMetaMeshId: Kubernetes
           gatewayProxies:

--- a/environments/gloo-edge/gateway-api/with-istio-sidecar/httpbin-app/base/httpbin-ns.yaml
+++ b/environments/gloo-edge/gateway-api/with-istio-sidecar/httpbin-app/base/httpbin-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: httpbin
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-edge/gateway-api/with-istio-sidecar/istio/base/istio-base.yaml
+++ b/environments/gloo-edge/gateway-api/with-istio-sidecar/istio/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-edge/gateway-api/with-istio-sidecar/istio/base/istiod.yaml
+++ b/environments/gloo-edge/gateway-api/with-istio-sidecar/istio/base/istiod.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
         global:
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           accessLogFile: /dev/stdout
           enableAutoMtls: true

--- a/environments/gloo-edge/gateway-api/with-istio-sidecar/istio/base/istiod.yaml
+++ b/environments/gloo-edge/gateway-api/with-istio-sidecar/istio/base/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
           tag: 1.23.0-solo
@@ -40,6 +40,6 @@ spec:
   ignoreDifferences:
     - group: admissionregistration.k8s.io
       kind: ValidatingWebhookConfiguration
-      name: istio-validator-1-22-istio-system
+      name: istio-validator-1-23-istio-system
       jsonPointers:
         - /webhooks/0/failurePolicy

--- a/environments/gloo-edge/gateway-api/with-istio-sidecar/istio/base/kiali.yaml
+++ b/environments/gloo-edge/gateway-api/with-istio-sidecar/istio/base/kiali.yaml
@@ -74,7 +74,7 @@ data:
       pod_annotations: {}
       pod_labels:
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       priority_class_name: ""
       replicas: 1
       resources:
@@ -116,9 +116,9 @@ data:
         url: http://prometheus:9090/prometheus
       ### add the following if using revisioned based istio installation
       istio:
-        config_map_name: istio-1-22
-        istio_sidecar_injector_config_map_name: istio-sidecar-injector-1-22
-        istiod_deployment_name: istiod-1-22
+        config_map_name: istio-1-23
+        istio_sidecar_injector_config_map_name: istio-sidecar-injector-1-23
+        istiod_deployment_name: istiod-1-23
         root_namespace: istio-system
     identity:
       cert_file: ""

--- a/environments/gloo-edge/gateway-api/with-istio-sidecar/istio/test.sh
+++ b/environments/gloo-edge/gateway-api/with-istio-sidecar/istio/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istiod-1-22 istio-system 10 ${cluster_context}
-#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-22 istio-eastwest 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istiod-1-23 istio-system 10 ${cluster_context}
+#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-23 istio-eastwest 10 ${cluster_context}

--- a/environments/gloo-gateway/bookinfo/README.md
+++ b/environments/gloo-gateway/bookinfo/README.md
@@ -12,11 +12,11 @@ The `gloo-gateway/backstage-bookinfo-httpbin` environment deploys the core compo
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -41,7 +41,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -82,7 +82,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-gateway/bookinfo/README.md
+++ b/environments/gloo-gateway/bookinfo/README.md
@@ -11,11 +11,11 @@ The `gloo-gateway/backstage-bookinfo-httpbin` environment deploys the core compo
 ## Environment descriptions
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILM)
+    - istio 1.23.0-solo (ILM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-gateway/bookinfo/bookinfo-app/base/bookinfo-backends-ns.yaml
+++ b/environments/gloo-gateway/bookinfo/bookinfo-app/base/bookinfo-backends-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bookinfo-backends
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/bookinfo/bookinfo-app/base/bookinfo-frontends-ns.yaml
+++ b/environments/gloo-gateway/bookinfo/bookinfo-app/base/bookinfo-frontends-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bookinfo-frontends
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/bookinfo/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/bookinfo/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-gateway/bookinfo/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/bookinfo/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-gateway/bookinfo/homer-app/localhost/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/bookinfo/homer-app/localhost/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-gateway/bookinfo/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-gateway/bookinfo/homer-app/localhost/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-gateway/bookinfo/ilm/README.md
+++ b/environments/gloo-gateway/bookinfo/ilm/README.md
@@ -31,11 +31,11 @@ The `gloo-gateway/backstage-bookinfo-httpbin` environment deploys the core compo
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilcm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILCM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -58,7 +58,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -99,7 +99,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-gateway/bookinfo/ilm/README.md
+++ b/environments/gloo-gateway/bookinfo/ilm/README.md
@@ -30,11 +30,11 @@ The `gloo-gateway/backstage-bookinfo-httpbin` environment deploys the core compo
 ## Overlay description
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilcm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILCM)
+    - istio 1.23.0-solo (ILCM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-gateway/core/README.md
+++ b/environments/gloo-gateway/core/README.md
@@ -11,11 +11,11 @@ The `gloo-gateway/core` environment deploys the core components of a single clus
 ## Environment descriptions
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - lifecyclemanager:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILM)
+    - istio 1.23.0-solo (ILM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-gateway/core/README.md
+++ b/environments/gloo-gateway/core/README.md
@@ -12,11 +12,11 @@ The `gloo-gateway/core` environment deploys the core components of a single clus
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - lifecyclemanager:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -37,7 +37,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -78,7 +78,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-gateway/core/clusterconfig/base/gloo-mesh-addons-ns.yaml
+++ b/environments/gloo-gateway/core/clusterconfig/base/gloo-mesh-addons-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: gloo-mesh-addons
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/core/clusterconfig/base/httpbin-ns.yaml
+++ b/environments/gloo-gateway/core/clusterconfig/base/httpbin-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: httpbin
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/core/clusterconfig/base/istio-eastwest-ns.yaml
+++ b/environments/gloo-gateway/core/clusterconfig/base/istio-eastwest-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: istio-eastwest
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/core/clusterconfig/base/istio-gateways-ns.yaml
+++ b/environments/gloo-gateway/core/clusterconfig/base/istio-gateways-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: istio-gateways
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/core/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-gateway/core/gloo-platform/base/gloo-platform-helm.yaml
@@ -63,7 +63,7 @@ spec:
             #                annotations:
             #                    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             #                labels:
-            #                    istio.io/rev: 1-22
+            #                    istio.io/rev: 1-23
             #                    sidecar.istio.io/inject: "true"
             enabled: true
             serviceType: ClusterIP

--- a/environments/gloo-gateway/core/gloo-platform/base/mgmt-grafana.yaml
+++ b/environments/gloo-gateway/core/gloo-platform/base/mgmt-grafana.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-gateway/core/gloo-platform/tracing/gloo-platform-helm.yaml
+++ b/environments/gloo-gateway/core/gloo-platform/tracing/gloo-platform-helm.yaml
@@ -63,7 +63,7 @@ spec:
             #                annotations:
             #                    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             #                labels:
-            #                    istio.io/rev: 1-22
+            #                    istio.io/rev: 1-23
             #                    sidecar.istio.io/inject: "true"
             enabled: true
             serviceType: ClusterIP

--- a/environments/gloo-gateway/core/gloo-platform/tracing/mgmt-grafana.yaml
+++ b/environments/gloo-gateway/core/gloo-platform/tracing/mgmt-grafana.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-gateway/core/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/core/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-gateway/core/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-gateway/core/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-gateway/core/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/core/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-gateway/core/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/core/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-gateway/core/homer-app/lb-discovery/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/core/homer-app/lb-discovery/homer-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/core/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-gateway/core/homer-app/lb-discovery/init.sh
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/environments/gloo-gateway/core/istio/helm/base/grafana.yaml
+++ b/environments/gloo-gateway/core/istio/helm/base/grafana.yaml
@@ -126,7 +126,7 @@ spec:
         app.kubernetes.io/instance: grafana
         app: grafana
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
         checksum/config: 0db0166dec9b75eb6486494512ab843bc085e0806457bc09e92597a418a115ae

--- a/environments/gloo-gateway/core/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-gateway/core/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-gateway/core/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-gateway/core/istio/helm/base/istio-ingressgateway.yaml
@@ -19,9 +19,9 @@ spec:
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
-        name: "istio-ingressgateway-1-22"
+        name: "istio-ingressgateway-1-23"
         # revision declares which revision this gateway is a part of
-        revision: "1-22"
+        revision: "1-23"
         
         replicaCount: 1
         

--- a/environments/gloo-gateway/core/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-gateway/core/istio/helm/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-gateway/core/istio/helm/base/istiod.yaml
+++ b/environments/gloo-gateway/core/istio/helm/base/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-gateway/core/istio/helm/base/istiod.yaml
+++ b/environments/gloo-gateway/core/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: mgmt
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           trustDomain: mgmt
           accessLogFile: /dev/stdout

--- a/environments/gloo-gateway/core/istio/helm/test.sh
+++ b/environments/gloo-gateway/core/istio/helm/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}

--- a/environments/gloo-gateway/core/istio/helm/tracing/grafana.yaml
+++ b/environments/gloo-gateway/core/istio/helm/tracing/grafana.yaml
@@ -126,7 +126,7 @@ spec:
         app.kubernetes.io/instance: grafana
         app: grafana
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
         checksum/config: 0db0166dec9b75eb6486494512ab843bc085e0806457bc09e92597a418a115ae

--- a/environments/gloo-gateway/core/istio/helm/tracing/istio-base.yaml
+++ b/environments/gloo-gateway/core/istio/helm/tracing/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-gateway/core/istio/helm/tracing/istio-ingressgateway.yaml
+++ b/environments/gloo-gateway/core/istio/helm/tracing/istio-ingressgateway.yaml
@@ -19,9 +19,9 @@ spec:
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
-        name: "istio-ingressgateway-1-22"
+        name: "istio-ingressgateway-1-23"
         # revision declares which revision this gateway is a part of
-        revision: "1-22"
+        revision: "1-23"
         
         replicaCount: 1
         

--- a/environments/gloo-gateway/core/istio/helm/tracing/istio-ingressgateway.yaml
+++ b/environments/gloo-gateway/core/istio/helm/tracing/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-gateway/core/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-gateway/core/istio/helm/tracing/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: mgmt
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-gateway/core/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-gateway/core/istio/helm/tracing/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-gateway/core/istio/lifecyclemanager/base/glcm-ns-mgmt.yaml
+++ b/environments/gloo-gateway/core/istio/lifecyclemanager/base/glcm-ns-mgmt.yaml
@@ -8,8 +8,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "-7"
 spec:
   installations:
-      # The revision for this installation, such as 1-22
-    - gatewayRevision: 1-22
+      # The revision for this installation, such as 1-23
+    - gatewayRevision: 1-23
       # List all workload clusters to install Istio into
       clusters:
       - name: mgmt

--- a/environments/gloo-gateway/core/istio/lifecyclemanager/base/glcm-ns-mgmt.yaml
+++ b/environments/gloo-gateway/core/istio/lifecyclemanager/base/glcm-ns-mgmt.yaml
@@ -22,7 +22,7 @@ spec:
         # You get the repo key from your Solo Account Representative.
         hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
         # The Solo.io Gloo Istio tag
-        tag: 1.22.3-patch1-solo-solo
+        tag: 1.23.0-solo-solo
         values:
           gateways:
             istio-ingressgateway:

--- a/environments/gloo-gateway/core/istio/lifecyclemanager/base/grafana.yaml
+++ b/environments/gloo-gateway/core/istio/lifecyclemanager/base/grafana.yaml
@@ -126,7 +126,7 @@ spec:
         app.kubernetes.io/instance: grafana
         app: grafana
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
         checksum/config: 0db0166dec9b75eb6486494512ab843bc085e0806457bc09e92597a418a115ae

--- a/environments/gloo-gateway/core/istio/lifecyclemanager/base/ilcm-mgmt.yaml
+++ b/environments/gloo-gateway/core/istio/lifecyclemanager/base/ilcm-mgmt.yaml
@@ -7,8 +7,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "-8"
 spec:
   installations:
-      # The revision for this installation, such as 1-22
-    - revision: 1-22
+      # The revision for this installation, such as 1-23
+    - revision: 1-23
       # List all workload clusters to install Istio into
       clusters:
       - name: mgmt

--- a/environments/gloo-gateway/core/istio/lifecyclemanager/base/ilcm-mgmt.yaml
+++ b/environments/gloo-gateway/core/istio/lifecyclemanager/base/ilcm-mgmt.yaml
@@ -28,7 +28,7 @@ spec:
         # You get the repo key from your Solo Account Representative.
         hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
         # Any Solo.io Gloo Istio tag
-        tag: 1.22.3-patch1-solo
+        tag: 1.23.0-solo
         namespace: istio-system
         # Mesh configuration
         meshConfig:

--- a/environments/gloo-gateway/core/istio/lifecyclemanager/base/istio-ingressgateway-svc.yaml
+++ b/environments/gloo-gateway/core/istio/lifecyclemanager/base/istio-ingressgateway-svc.yaml
@@ -4,11 +4,11 @@ metadata:
   labels:
     app: istio-ingressgateway
     istio: ingressgateway
-    revision: 1-22
+    revision: 1-23
   annotations:
     # AWS NLB Annotation
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-  name: istio-ingressgateway-1-22
+  name: istio-ingressgateway-1-23
   namespace: istio-gateways
 spec:
   ports:
@@ -23,5 +23,5 @@ spec:
   selector:
     app: istio-ingressgateway
     istio: ingressgateway
-    revision: 1-22
+    revision: 1-23
   type: LoadBalancer

--- a/environments/gloo-gateway/core/istio/lifecyclemanager/test.sh
+++ b/environments/gloo-gateway/core/istio/lifecyclemanager/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
-#./tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-22 istio-eastwest 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
+#./tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-23 istio-eastwest 10 ${cluster_context}

--- a/environments/gloo-gateway/httpbin/README.md
+++ b/environments/gloo-gateway/httpbin/README.md
@@ -11,11 +11,11 @@ The `gloo-gateway/httpbin` environment deploys the core components of a single c
 ## Environment descriptions
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILM)
+    - istio 1.23.0-solo (ILM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-gateway/httpbin/README.md
+++ b/environments/gloo-gateway/httpbin/README.md
@@ -12,11 +12,11 @@ The `gloo-gateway/httpbin` environment deploys the core components of a single c
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -38,7 +38,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o '{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -79,7 +79,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-gateway/httpbin/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/httpbin/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-gateway/httpbin/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/httpbin/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-gateway/httpbin/homer-app/localhost/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/httpbin/homer-app/localhost/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-gateway/httpbin/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-gateway/httpbin/homer-app/localhost/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-gateway/httpbin/httpbin-app/base/httpbin-in-mesh.yaml
+++ b/environments/gloo-gateway/httpbin/httpbin-app/base/httpbin-in-mesh.yaml
@@ -39,7 +39,7 @@ spec:
       labels:
         app: in-mesh
         version: v1
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
     spec:
       serviceAccountName: in-mesh
       containers:
@@ -68,7 +68,7 @@ spec:
       labels:
         app: in-mesh
         version: v2
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
     spec:
       serviceAccountName: in-mesh
       containers:

--- a/environments/gloo-gateway/httpbin/ilm/README.md
+++ b/environments/gloo-gateway/httpbin/ilm/README.md
@@ -31,11 +31,11 @@ The `gloo-gateway/backstage-bookinfo-httpbin` environment deploys the core compo
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilcm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILCM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -58,7 +58,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -99,7 +99,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-gateway/httpbin/ilm/README.md
+++ b/environments/gloo-gateway/httpbin/ilm/README.md
@@ -30,11 +30,11 @@ The `gloo-gateway/backstage-bookinfo-httpbin` environment deploys the core compo
 ## Overlay description
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilcm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILCM)
+    - istio 1.23.0-solo (ILCM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-gateway/int-ext-portal/README.md
+++ b/environments/gloo-gateway/int-ext-portal/README.md
@@ -10,7 +10,7 @@ The `gloo-gateway/portal` environment deploys the core components of a single cl
 
 ## Environment Description
 - gloo mesh 2.6.0
-- istio 1.22.3-patch1-solo (Helm)
+- istio 1.23.0-solo (Helm)
 - revision: 1-22
 
 ## Application description

--- a/environments/gloo-gateway/int-ext-portal/README.md
+++ b/environments/gloo-gateway/int-ext-portal/README.md
@@ -11,7 +11,7 @@ The `gloo-gateway/portal` environment deploys the core components of a single cl
 ## Environment Description
 - gloo mesh 2.6.0
 - istio 1.23.0-solo (Helm)
-- revision: 1-22
+- revision: 1-23
 
 ## Application description
 
@@ -37,7 +37,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -78,7 +78,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-gateway/int-ext-portal/applications/backstage/backstage-ns.yaml
+++ b/environments/gloo-gateway/int-ext-portal/applications/backstage/backstage-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: backstage
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/int-ext-portal/applications/external-portal-frontend/external-portal-ns.yaml
+++ b/environments/gloo-gateway/int-ext-portal/applications/external-portal-frontend/external-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: external-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/int-ext-portal/applications/httpbin-app/dev/httpbin.yaml
+++ b/environments/gloo-gateway/int-ext-portal/applications/httpbin-app/dev/httpbin.yaml
@@ -38,7 +38,7 @@ spec:
         app: httpbin
         version: v1
         # uncomment for pod label injection
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
     spec:
       containers:
       - image: docker.io/kennethreitz/httpbin

--- a/environments/gloo-gateway/int-ext-portal/applications/httpbin-app/httpbin-prod-ns.yaml
+++ b/environments/gloo-gateway/int-ext-portal/applications/httpbin-app/httpbin-prod-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: httpbin-prod
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/int-ext-portal/applications/petstore-app/petstore-ns.yaml
+++ b/environments/gloo-gateway/int-ext-portal/applications/petstore-app/petstore-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: petstore
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/int-ext-portal/applications/petstore-app/prod/petstore-prod-ns.yaml
+++ b/environments/gloo-gateway/int-ext-portal/applications/petstore-app/prod/petstore-prod-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: petstore-prod
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/int-ext-portal/applications/tracks-app/prod/tracks-prod-ns.yaml
+++ b/environments/gloo-gateway/int-ext-portal/applications/tracks-app/prod/tracks-prod-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: tracks-prod
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/int-ext-portal/applications/tracks-app/tracks-ns.yaml
+++ b/environments/gloo-gateway/int-ext-portal/applications/tracks-app/tracks-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: tracks
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/int-ext-portal/homer-app/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/int-ext-portal/homer-app/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-gateway/int-ext-portal/homer-app/homer-portal.yaml
+++ b/environments/gloo-gateway/int-ext-portal/homer-app/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-gateway/int-ext-portal/internal-portal-workspace-config/portal-ns.yaml
+++ b/environments/gloo-gateway/int-ext-portal/internal-portal-workspace-config/portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/onlineboutique/README.md
+++ b/environments/gloo-gateway/onlineboutique/README.md
@@ -12,16 +12,16 @@ The `gloo-gateway/onlineboutique` environment deploys the core components of a s
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - tracing:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
     - tracing config enabled
 - ilm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -43,7 +43,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -84,7 +84,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-gateway/onlineboutique/README.md
+++ b/environments/gloo-gateway/onlineboutique/README.md
@@ -11,16 +11,16 @@ The `gloo-gateway/onlineboutique` environment deploys the core components of a s
 ## Environment descriptions
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - tracing:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
     - tracing config enabled
 - ilm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILM)
+    - istio 1.23.0-solo (ILM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-gateway/onlineboutique/glootest.com/README.md
+++ b/environments/gloo-gateway/onlineboutique/glootest.com/README.md
@@ -25,11 +25,11 @@ The `gloo-gateway/onlineboutique` environment deploys the core components of a s
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilcm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILCM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -49,7 +49,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -90,7 +90,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-gateway/onlineboutique/glootest.com/README.md
+++ b/environments/gloo-gateway/onlineboutique/glootest.com/README.md
@@ -24,11 +24,11 @@ The `gloo-gateway/onlineboutique` environment deploys the core components of a s
 ## Overlay description
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilcm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILCM)
+    - istio 1.23.0-solo (ILCM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-gateway/onlineboutique/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/onlineboutique/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-gateway/onlineboutique/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/onlineboutique/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-gateway/onlineboutique/homer-app/lb-discovery/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/onlineboutique/homer-app/lb-discovery/homer-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/onlineboutique/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-gateway/onlineboutique/homer-app/lb-discovery/init.sh
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/environments/gloo-gateway/onlineboutique/homer-app/localhost/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/onlineboutique/homer-app/localhost/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-gateway/onlineboutique/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-gateway/onlineboutique/homer-app/localhost/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-gateway/onlineboutique/homer-app/tracing/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/onlineboutique/homer-app/tracing/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-gateway/onlineboutique/homer-app/tracing/homer-portal.yaml
+++ b/environments/gloo-gateway/onlineboutique/homer-app/tracing/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-gateway/onlineboutique/ilm/README.md
+++ b/environments/gloo-gateway/onlineboutique/ilm/README.md
@@ -25,11 +25,11 @@ The `gloo-gateway/onlineboutique` environment deploys the core components of a s
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilcm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILCM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -49,7 +49,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -90,7 +90,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-gateway/onlineboutique/ilm/README.md
+++ b/environments/gloo-gateway/onlineboutique/ilm/README.md
@@ -24,11 +24,11 @@ The `gloo-gateway/onlineboutique` environment deploys the core components of a s
 ## Overlay description
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilcm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILCM)
+    - istio 1.23.0-solo (ILCM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-gateway/onlineboutique/online-boutique-app/base/backend-apis-ns.yaml
+++ b/environments/gloo-gateway/onlineboutique/online-boutique-app/base/backend-apis-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: backend-apis
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/onlineboutique/online-boutique-app/base/web-ui-ns.yaml
+++ b/environments/gloo-gateway/onlineboutique/online-boutique-app/base/web-ui-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: web-ui
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/README.md
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/README.md
@@ -12,11 +12,11 @@ The `gloo-gateway/progressive-delivery-argo-rollouts` environment deploys the co
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -62,7 +62,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -103,7 +103,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/README.md
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/README.md
@@ -11,11 +11,11 @@ The `gloo-gateway/progressive-delivery-argo-rollouts` environment deploys the co
 ## Environment descriptions
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILM)
+    - istio 1.23.0-solo (ILM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/glootest.com/README.md
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/glootest.com/README.md
@@ -25,11 +25,11 @@ The `gloo-gateway/onlineboutique` environment deploys the core components of a s
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilcm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILCM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -49,7 +49,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -90,7 +90,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/glootest.com/README.md
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/glootest.com/README.md
@@ -24,11 +24,11 @@ The `gloo-gateway/onlineboutique` environment deploys the core components of a s
 ## Overlay description
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilcm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILCM)
+    - istio 1.23.0-solo (ILCM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/helloworld-rollout/base/helloworld-ns.yaml
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/helloworld-rollout/base/helloworld-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: helloworld
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/lb-discovery/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/lb-discovery/homer-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/lb-discovery/init.sh
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/localhost/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/localhost/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/homer-app/localhost/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/ilm/README.md
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/ilm/README.md
@@ -27,7 +27,7 @@ The `gloo-gateway/otel/progressive-delivery-argo-rollouts` environment deploys t
 ## Overlay description
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/ilm/README.md
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/ilm/README.md
@@ -28,7 +28,7 @@ The `gloo-gateway/otel/progressive-delivery-argo-rollouts` environment deploys t
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -72,7 +72,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -113,7 +113,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-gateway/progressive-delivery-argo-rollouts/rollouts-demo/base/rollouts-demo-ns.yaml
+++ b/environments/gloo-gateway/progressive-delivery-argo-rollouts/rollouts-demo/base/rollouts-demo-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: rollouts-demo
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/solowallet/README.md
+++ b/environments/gloo-gateway/solowallet/README.md
@@ -12,11 +12,11 @@ The `gloo-gateway/solowallet` environment deploys the core components of a singl
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -38,7 +38,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -79,7 +79,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-gateway/solowallet/README.md
+++ b/environments/gloo-gateway/solowallet/README.md
@@ -11,11 +11,11 @@ The `gloo-gateway/solowallet` environment deploys the core components of a singl
 ## Environment descriptions
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILM)
+    - istio 1.23.0-solo (ILM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-gateway/solowallet/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/solowallet/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-gateway/solowallet/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-gateway/solowallet/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-gateway/solowallet/homer-app/lb-discovery/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/solowallet/homer-app/lb-discovery/homer-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-gateway/solowallet/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-gateway/solowallet/homer-app/lb-discovery/init.sh
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/environments/gloo-gateway/solowallet/homer-app/localhost/homer-portal-ns.yaml
+++ b/environments/gloo-gateway/solowallet/homer-app/localhost/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-gateway/solowallet/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-gateway/solowallet/homer-app/localhost/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-gateway/solowallet/solowallet-app/base/bank-demo-ns.yaml
+++ b/environments/gloo-gateway/solowallet/solowallet-app/base/bank-demo-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bank-demo
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-mesh-core/additional-cluster-1/README.md
+++ b/environments/gloo-mesh-core/additional-cluster-1/README.md
@@ -10,9 +10,9 @@ The `gloo-mesh-core/additional-cluster-1` environment bootstraps an additional w
 ## Environment descriptions
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - lifecyclemanager:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILM)
+    - istio 1.23.0-solo (ILM)
     - revision: 1-22

--- a/environments/gloo-mesh-core/additional-cluster-1/README.md
+++ b/environments/gloo-mesh-core/additional-cluster-1/README.md
@@ -11,8 +11,8 @@ The `gloo-mesh-core/additional-cluster-1` environment bootstraps an additional w
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - lifecyclemanager:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILM)
-    - revision: 1-22
+    - revision: 1-23

--- a/environments/gloo-mesh-core/additional-cluster-1/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-mesh-core/additional-cluster-1/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-core/additional-cluster-1/homer-app/lb-discovery/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/homer-app/lb-discovery/homer-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-mesh-core/additional-cluster-1/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-mesh-core/additional-cluster-1/homer-app/lb-discovery/init.sh
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/grafana.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/grafana.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-ingressgateway.yaml
@@ -19,9 +19,9 @@ spec:
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
-        name: "istio-ingressgateway-1-22"
+        name: "istio-ingressgateway-1-23"
         # revision declares which revision this gateway is a part of
-        revision: "1-22"
+        revision: "1-23"
         
         replicaCount: 1
         

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: additional-cluster-1
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           trustDomain: additional-cluster-1
           accessLogFile: /dev/stdout

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/test.sh
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/lifecyclemanager/base/grafana.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/lifecyclemanager/base/grafana.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/lifecyclemanager/base/istio-ingressgateway-svc.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/lifecyclemanager/base/istio-ingressgateway-svc.yaml
@@ -4,11 +4,11 @@ metadata:
   labels:
     app: istio-ingressgateway
     istio: ingressgateway
-    revision: 1-22
+    revision: 1-23
   annotations:
     # AWS NLB Annotation
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-  name: istio-ingressgateway-1-22
+  name: istio-ingressgateway-1-23
   namespace: istio-gateways
 spec:
   ports:
@@ -23,5 +23,5 @@ spec:
   selector:
     app: istio-ingressgateway
     istio: ingressgateway
-    revision: 1-22
+    revision: 1-23
   type: LoadBalancer

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/lifecyclemanager/test.sh
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/lifecyclemanager/test.sh
@@ -3,7 +3,7 @@
 if [ "${environment_overlay}" == "ilcm" ] ; then 
      echo ""
   else 
-     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
      #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}
   fi
 

--- a/environments/gloo-mesh-core/additional-cluster-1/online-boutique-app/base/backend-apis-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/online-boutique-app/base/backend-apis-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: backend-apis
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-mesh-core/additional-cluster-1/online-boutique-app/base/web-ui-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/online-boutique-app/base/web-ui-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: web-ui
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-mesh-core/additional-cluster-2/README.md
+++ b/environments/gloo-mesh-core/additional-cluster-2/README.md
@@ -11,8 +11,8 @@ The `gloo-mesh-core/additional-cluster-2` environment bootstraps an additional w
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - lifecyclemanager:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILM)
-    - revision: 1-22
+    - revision: 1-23

--- a/environments/gloo-mesh-core/additional-cluster-2/README.md
+++ b/environments/gloo-mesh-core/additional-cluster-2/README.md
@@ -10,9 +10,9 @@ The `gloo-mesh-core/additional-cluster-2` environment bootstraps an additional w
 ## Environment descriptions
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - lifecyclemanager:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILM)
+    - istio 1.23.0-solo (ILM)
     - revision: 1-22

--- a/environments/gloo-mesh-core/additional-cluster-2/bookinfo-app/base/bookinfo-backends-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/bookinfo-app/base/bookinfo-backends-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bookinfo-backends
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-mesh-core/additional-cluster-2/bookinfo-app/base/bookinfo-frontends-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/bookinfo-app/base/bookinfo-frontends-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bookinfo-frontends
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-mesh-core/additional-cluster-2/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-mesh-core/additional-cluster-2/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-core/additional-cluster-2/homer-app/lb-discovery/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/homer-app/lb-discovery/homer-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-mesh-core/additional-cluster-2/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-mesh-core/additional-cluster-2/homer-app/lb-discovery/init.sh
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/grafana.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/grafana.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-ingressgateway.yaml
@@ -19,9 +19,9 @@ spec:
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
-        name: "istio-ingressgateway-1-22"
+        name: "istio-ingressgateway-1-23"
         # revision declares which revision this gateway is a part of
-        revision: "1-22"
+        revision: "1-23"
         
         replicaCount: 1
         

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: additional-cluster-2
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           trustDomain: additional-cluster-2
           accessLogFile: /dev/stdout

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/test.sh
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/lifecyclemanager/base/grafana.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/lifecyclemanager/base/grafana.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/lifecyclemanager/base/istio-ingressgateway-svc.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/lifecyclemanager/base/istio-ingressgateway-svc.yaml
@@ -4,11 +4,11 @@ metadata:
   labels:
     app: istio-ingressgateway
     istio: ingressgateway
-    revision: 1-22
+    revision: 1-23
   annotations:
     # AWS NLB Annotation
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-  name: istio-ingressgateway-1-22
+  name: istio-ingressgateway-1-23
   namespace: istio-gateways
 spec:
   ports:
@@ -23,5 +23,5 @@ spec:
   selector:
     app: istio-ingressgateway
     istio: ingressgateway
-    revision: 1-22
+    revision: 1-23
   type: LoadBalancer

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/lifecyclemanager/test.sh
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/lifecyclemanager/test.sh
@@ -3,7 +3,7 @@
 if [ "${environment_overlay}" == "ilcm" ] ; then 
      echo ""
   else 
-     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
      #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}
   fi
 

--- a/environments/gloo-mesh-core/singlecluster/README.md
+++ b/environments/gloo-mesh-core/singlecluster/README.md
@@ -10,8 +10,8 @@ The `gloo-mesh-core/singlecluster` environment deploys the core components of a 
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - lifecyclemanager:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILM)
-    - revision: 1-22
+    - revision: 1-23

--- a/environments/gloo-mesh-core/singlecluster/README.md
+++ b/environments/gloo-mesh-core/singlecluster/README.md
@@ -9,9 +9,9 @@ The `gloo-mesh-core/singlecluster` environment deploys the core components of a 
 ## Environment descriptions
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - lifecyclemanager:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILM)
+    - istio 1.23.0-solo (ILM)
     - revision: 1-22

--- a/environments/gloo-mesh-core/singlecluster/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-core/singlecluster/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-mesh-core/singlecluster/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-mesh-core/singlecluster/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-core/singlecluster/homer-app/lb-discovery/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-core/singlecluster/homer-app/lb-discovery/homer-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-mesh-core/singlecluster/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-mesh-core/singlecluster/homer-app/lb-discovery/init.sh
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/grafana.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/grafana.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-ingressgateway.yaml
@@ -19,9 +19,9 @@ spec:
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
-        name: "istio-ingressgateway-1-22"
+        name: "istio-ingressgateway-1-23"
         # revision declares which revision this gateway is a part of
-        revision: "1-22"
+        revision: "1-23"
         
         replicaCount: 1
         

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: mgmt
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           trustDomain: mgmt
           accessLogFile: /dev/stdout

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/test.sh
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}

--- a/environments/gloo-mesh-core/singlecluster/istio/lifecyclemanager/base/gatewaylifecyclemanager.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/lifecyclemanager/base/gatewaylifecyclemanager.yaml
@@ -21,7 +21,7 @@ spec:
         # You get the repo key from your Solo Account Representative.
         hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
         # The Solo.io Gloo Istio tag
-        tag: 1.22.3-patch1-solo
+        tag: 1.23.0-solo
         values:
           gateways:
             istio-ingressgateway:

--- a/environments/gloo-mesh-core/singlecluster/istio/lifecyclemanager/base/gatewaylifecyclemanager.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/lifecyclemanager/base/gatewaylifecyclemanager.yaml
@@ -7,8 +7,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "-7"
 spec:
   installations:
-      # The revision for this installation, such as 1-22
-    - gatewayRevision: 1-22
+      # The revision for this installation, such as 1-23
+    - gatewayRevision: 1-23
       # List all workload clusters to install Istio into
       clusters:
       - name: mgmt

--- a/environments/gloo-mesh-core/singlecluster/istio/lifecyclemanager/base/grafana.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/lifecyclemanager/base/grafana.yaml
@@ -126,7 +126,7 @@ spec:
         app.kubernetes.io/instance: grafana
         app: grafana
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
         checksum/config: 0db0166dec9b75eb6486494512ab843bc085e0806457bc09e92597a418a115ae

--- a/environments/gloo-mesh-core/singlecluster/istio/lifecyclemanager/base/istio-ingressgateway-svc.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/lifecyclemanager/base/istio-ingressgateway-svc.yaml
@@ -26,5 +26,5 @@ spec:
   selector:
     app: istio-ingressgateway
     istio: ingressgateway
-    revision: 1-22
+    revision: 1-23
   type: LoadBalancer

--- a/environments/gloo-mesh-core/singlecluster/istio/lifecyclemanager/base/istiolifecyclemanager.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/lifecyclemanager/base/istiolifecyclemanager.yaml
@@ -24,7 +24,7 @@ spec:
         # You get the repo key from your Solo Account Representative.
         hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
         # Any Solo.io Gloo Istio tag
-        tag: 1.22.3-patch1-solo
+        tag: 1.23.0-solo
         namespace: istio-system
         # Mesh configuration
         meshConfig:

--- a/environments/gloo-mesh-core/singlecluster/istio/lifecyclemanager/base/istiolifecyclemanager.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/lifecyclemanager/base/istiolifecyclemanager.yaml
@@ -7,8 +7,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "-8"
 spec:
   installations:
-      # The revision for this installation, such as 1-22
-    - revision: 1-22
+      # The revision for this installation, such as 1-23
+    - revision: 1-23
       # List all workload clusters to install Istio into
       clusters:
       - name: mgmt

--- a/environments/gloo-mesh-core/singlecluster/istio/lifecyclemanager/test.sh
+++ b/environments/gloo-mesh-core/singlecluster/istio/lifecyclemanager/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-operator-1-22 gm-iop-1-22 10 ${cluster_context}
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istiod-1-22 istio-system 10 ${cluster_context}
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
-#./tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-22 istio-eastwest 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-operator-1-23 gm-iop-1-23 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istiod-1-23 istio-system 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
+#./tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-23 istio-eastwest 10 ${cluster_context}

--- a/environments/gloo-mesh-core/singlecluster/online-boutique-app/base/backend-apis-ns.yaml
+++ b/environments/gloo-mesh-core/singlecluster/online-boutique-app/base/backend-apis-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: backend-apis
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-mesh-core/singlecluster/online-boutique-app/base/web-ui-ns.yaml
+++ b/environments/gloo-mesh-core/singlecluster/online-boutique-app/base/web-ui-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: web-ui
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-platform/core/cluster1/README.md
+++ b/environments/gloo-platform/core/cluster1/README.md
@@ -11,11 +11,11 @@ The `gloo-platform/core/cluster1` environment deploys the `cluster1` worker for 
 ## Environment description
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilcm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILCM)
+    - istio 1.23.0-solo (ILCM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-platform/core/cluster1/README.md
+++ b/environments/gloo-platform/core/cluster1/README.md
@@ -12,11 +12,11 @@ The `gloo-platform/core/cluster1` environment deploys the `cluster1` worker for 
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilcm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILCM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -37,7 +37,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -78,7 +78,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-platform/core/cluster1/clusterconfig/base/bookinfo-backends-ns.yaml
+++ b/environments/gloo-platform/core/cluster1/clusterconfig/base/bookinfo-backends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
   name: bookinfo-backends

--- a/environments/gloo-platform/core/cluster1/clusterconfig/base/bookinfo-frontends-ns.yaml
+++ b/environments/gloo-platform/core/cluster1/clusterconfig/base/bookinfo-frontends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
   name: bookinfo-frontends

--- a/environments/gloo-platform/core/cluster1/gloo-platform/init.sh
+++ b/environments/gloo-platform/core/cluster1/gloo-platform/init.sh
@@ -120,7 +120,7 @@ spec:
             #service: 
             #  type: ClusterIP
             #podLabels:
-            #  istio.io/rev: 1-22
+            #  istio.io/rev: 1-23
             #podAnnotations:
             #  proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             image:

--- a/environments/gloo-platform/core/cluster1/istio/helm/base/grafana-helm.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/base/grafana-helm.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-platform/core/cluster1/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/base/istio-eastwestgateway.yaml
@@ -21,7 +21,7 @@ spec:
         # Name allows overriding the release name. Generally this should not be set
         name: "istio-eastwestgateway"
         # revision declares which revision this gateway is a part of
-        revision: "1-22"
+        revision: "1-23"
         
         replicaCount: 1
         
@@ -55,7 +55,7 @@ spec:
         
         # Labels to apply to all resources
         labels:
-          istio.io/rev: 1-22
+          istio.io/rev: 1-23
           istio: eastwestgateway
           topology.istio.io/network: cluster1
   syncPolicy:

--- a/environments/gloo-platform/core/cluster1/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/base/istio-eastwestgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/core/cluster1/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/base/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-platform/core/cluster1/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: cluster1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           trustDomain: cluster1
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/core/cluster1/istio/helm/test.sh
+++ b/environments/gloo-platform/core/cluster1/istio/helm/test.sh
@@ -3,7 +3,7 @@
 if [ "${environment_overlay}" == "ilcm" ] ; then 
      echo ""
   else 
-     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
      #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}
   fi
 

--- a/environments/gloo-platform/core/cluster1/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/tracing/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: cluster1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/core/cluster1/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/tracing/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-platform/core/cluster1/istio/lifecyclemanager/base/grafana-helm.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/lifecyclemanager/base/grafana-helm.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-platform/core/cluster1/istio/lifecyclemanager/base/istio-eastwestgateway-svc.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/lifecyclemanager/base/istio-eastwestgateway-svc.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: istio-ingressgateway
     istio: eastwestgateway
-    revision: 1-22
+    revision: 1-23
     topology.istio.io/network: cluster1
   annotations:
     # AWS NLB Annotation
@@ -36,6 +36,6 @@ spec:
   selector:
     app: istio-ingressgateway
     istio: eastwestgateway
-    revision: 1-22
+    revision: 1-23
     topology.istio.io/network: cluster1
   type: LoadBalancer

--- a/environments/gloo-platform/core/cluster1/istio/lifecyclemanager/test.sh
+++ b/environments/gloo-platform/core/cluster1/istio/lifecyclemanager/test.sh
@@ -3,7 +3,7 @@
 if [ "${environment_overlay}" == "ilcm" ] ; then 
      echo ""
   else 
-     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
      #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}
   fi
 

--- a/environments/gloo-platform/core/cluster2/README.md
+++ b/environments/gloo-platform/core/cluster2/README.md
@@ -11,11 +11,11 @@ The `gloo-platform/core/cluster2` environment deploys the `cluster2` worker for 
 ## Environment description
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilcm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILCM)
+    - istio 1.23.0-solo (ILCM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-platform/core/cluster2/README.md
+++ b/environments/gloo-platform/core/cluster2/README.md
@@ -12,11 +12,11 @@ The `gloo-platform/core/cluster2` environment deploys the `cluster2` worker for 
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilcm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILCM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -37,7 +37,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -78,7 +78,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-platform/core/cluster2/clusterconfig/base/bookinfo-backends-ns.yaml
+++ b/environments/gloo-platform/core/cluster2/clusterconfig/base/bookinfo-backends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
   name: bookinfo-backends

--- a/environments/gloo-platform/core/cluster2/clusterconfig/base/bookinfo-frontends-ns.yaml
+++ b/environments/gloo-platform/core/cluster2/clusterconfig/base/bookinfo-frontends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
   name: bookinfo-frontends

--- a/environments/gloo-platform/core/cluster2/gloo-platform/init.sh
+++ b/environments/gloo-platform/core/cluster2/gloo-platform/init.sh
@@ -120,7 +120,7 @@ spec:
             #service: 
             #  type: ClusterIP
             #podLabels:
-            #  istio.io/rev: 1-22
+            #  istio.io/rev: 1-23
             #podAnnotations:
             #  proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             image:

--- a/environments/gloo-platform/core/cluster2/istio/helm/base/grafana-helm.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/helm/base/grafana-helm.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-platform/core/cluster2/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/helm/base/istio-eastwestgateway.yaml
@@ -21,7 +21,7 @@ spec:
         # Name allows overriding the release name. Generally this should not be set
         name: "istio-eastwestgateway"
         # revision declares which revision this gateway is a part of
-        revision: "1-22"
+        revision: "1-23"
         
         replicaCount: 1
         
@@ -55,7 +55,7 @@ spec:
         
         # Labels to apply to all resources
         labels:
-          istio.io/rev: 1-22
+          istio.io/rev: 1-23
           istio: eastwestgateway
           topology.istio.io/network: cluster2
   syncPolicy:

--- a/environments/gloo-platform/core/cluster2/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/helm/base/istio-eastwestgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/core/cluster2/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/helm/base/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-platform/core/cluster2/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster2
           network: cluster2
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           trustDomain: cluster2
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/core/cluster2/istio/helm/test.sh
+++ b/environments/gloo-platform/core/cluster2/istio/helm/test.sh
@@ -3,7 +3,7 @@
 if [ "${environment_overlay}" == "ilcm" ] ; then 
      echo ""
   else 
-     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
      #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}
   fi
 

--- a/environments/gloo-platform/core/cluster2/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/helm/tracing/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster2
           network: cluster2
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/core/cluster2/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/helm/tracing/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-platform/core/cluster2/istio/lifecyclemanager/base/grafana-helm.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/lifecyclemanager/base/grafana-helm.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-platform/core/cluster2/istio/lifecyclemanager/base/istio-eastwestgateway-svc.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/lifecyclemanager/base/istio-eastwestgateway-svc.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: istio-ingressgateway
     istio: eastwestgateway
-    revision: 1-22
+    revision: 1-23
     topology.istio.io/network: cluster2
   annotations:
     # AWS NLB Annotation
@@ -36,6 +36,6 @@ spec:
   selector:
     app: istio-ingressgateway
     istio: eastwestgateway
-    revision: 1-22
+    revision: 1-23
     topology.istio.io/network: cluster2
   type: LoadBalancer

--- a/environments/gloo-platform/core/cluster2/istio/lifecyclemanager/test.sh
+++ b/environments/gloo-platform/core/cluster2/istio/lifecyclemanager/test.sh
@@ -3,7 +3,7 @@
 if [ "${environment_overlay}" == "ilcm" ] ; then 
      echo ""
   else 
-     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
      #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}
   fi
 

--- a/environments/gloo-platform/core/mgmt/README.md
+++ b/environments/gloo-platform/core/mgmt/README.md
@@ -19,11 +19,11 @@ When applied with `cluster1` and `cluster2` environments, here is a high level d
 ## Environment description
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilcm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILCM)
+    - istio 1.23.0-solo (ILCM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-platform/core/mgmt/README.md
+++ b/environments/gloo-platform/core/mgmt/README.md
@@ -20,11 +20,11 @@ When applied with `cluster1` and `cluster2` environments, here is a high level d
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilcm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILCM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -45,7 +45,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -86,7 +86,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-platform/core/mgmt/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-platform/core/mgmt/gloo-platform/base/gloo-platform-helm.yaml
@@ -63,7 +63,7 @@ spec:
             #                annotations:
             #                    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             #                labels:
-            #                    istio.io/rev: 1-22
+            #                    istio.io/rev: 1-23
             #                    sidecar.istio.io/inject: "true"
             enabled: true
             serviceType: ClusterIP
@@ -96,7 +96,7 @@ spec:
             #service: 
             #    type: ClusterIP
             #podLabels:
-            #    istio.io/rev: 1-22
+            #    istio.io/rev: 1-23
             #podAnnotations:
             #    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             image:

--- a/environments/gloo-platform/core/mgmt/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-platform/core/mgmt/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-platform/core/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/core/mgmt/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/core/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/core/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/grafana-helm.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/grafana-helm.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/istio-eastwestgateway.yaml
@@ -21,7 +21,7 @@ spec:
         # Name allows overriding the release name. Generally this should not be set
         name: "istio-eastwestgateway"
         # revision declares which revision this gateway is a part of
-        revision: "1-22"
+        revision: "1-23"
         
         replicaCount: 1
         
@@ -55,7 +55,7 @@ spec:
         
         # Labels to apply to all resources
         labels:
-          istio.io/rev: 1-22
+          istio.io/rev: 1-23
           istio: eastwestgateway
           topology.istio.io/network: mgmt
   syncPolicy:

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/istio-eastwestgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/istio-ingressgateway.yaml
@@ -19,9 +19,9 @@ spec:
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
-        name: "istio-ingressgateway-1-22"
+        name: "istio-ingressgateway-1-23"
         # revision declares which revision this gateway is a part of
-        revision: "1-22"
+        revision: "1-23"
         
         replicaCount: 1
         
@@ -49,7 +49,7 @@ spec:
         
         # Labels to apply to all resources
         labels:
-          istio.io/rev: 1-22
+          istio.io/rev: 1-23
           istio: mgmt-ingressgateway
   syncPolicy:
     automated: {}

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: mgmt
           network: mgmt
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           trustDomain: mgmt
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/core/mgmt/istio/helm/test.sh
+++ b/environments/gloo-platform/core/mgmt/istio/helm/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
-#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-22 istio-eastwest 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
+#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-23 istio-eastwest 10 ${cluster_context}

--- a/environments/gloo-platform/core/mgmt/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/tracing/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-platform/core/mgmt/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/tracing/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: mgmt
           network: mgmt
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ew-cluster1.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ew-cluster1.yaml
@@ -21,7 +21,7 @@ spec:
         # You get the repo key from your Solo Account Representative.
         hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
         # The Solo.io Gloo Istio tag
-        tag: 1.22.3-patch1-solo
+        tag: 1.23.0-solo
         values:
           gateways:
             istio-ingressgateway:

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ew-cluster1.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ew-cluster1.yaml
@@ -7,8 +7,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "-7"
 spec:
   installations:
-      # The revision for this installation, such as 1-22
-    - gatewayRevision: 1-22
+      # The revision for this installation, such as 1-23
+    - gatewayRevision: 1-23
       # List all workload clusters to install Istio into
       clusters:
       - name: cluster1

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ew-cluster2.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ew-cluster2.yaml
@@ -21,7 +21,7 @@ spec:
         # You get the repo key from your Solo Account Representative.
         hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
         # The Solo.io Gloo Istio tag
-        tag: 1.22.3-patch1-solo
+        tag: 1.23.0-solo
         values:
           gateways:
             istio-ingressgateway:

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ew-cluster2.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ew-cluster2.yaml
@@ -7,8 +7,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "-7"
 spec:
   installations:
-      # The revision for this installation, such as 1-22
-    - gatewayRevision: 1-22
+      # The revision for this installation, such as 1-23
+    - gatewayRevision: 1-23
       # List all workload clusters to install Istio into
       clusters:
       - name: cluster2

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ew-mgmt.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ew-mgmt.yaml
@@ -21,7 +21,7 @@ spec:
         # You get the repo key from your Solo Account Representative.
         hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
         # The Solo.io Gloo Istio tag
-        tag: 1.22.3-patch1-solo
+        tag: 1.23.0-solo
         values:
           gateways:
             istio-ingressgateway:

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ew-mgmt.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ew-mgmt.yaml
@@ -7,8 +7,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "-7"
 spec:
   installations:
-      # The revision for this installation, such as 1-22
-    - gatewayRevision: 1-22
+      # The revision for this installation, such as 1-23
+    - gatewayRevision: 1-23
       # List all workload clusters to install Istio into
       clusters:
       - name: mgmt

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ns-cluster1.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ns-cluster1.yaml
@@ -22,7 +22,7 @@ spec:
         # You get the repo key from your Solo Account Representative.
         hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
         # The Solo.io Gloo Istio tag
-        tag: 1.22.3-patch1-solo
+        tag: 1.23.0-solo
         values:
           gateways:
             istio-ingressgateway:

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ns-cluster1.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ns-cluster1.yaml
@@ -8,8 +8,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "-7"
 spec:
   installations:
-      # The revision for this installation, such as 1-22
-    - gatewayRevision: 1-22
+      # The revision for this installation, such as 1-23
+    - gatewayRevision: 1-23
       # List all workload clusters to install Istio into
       clusters:
       - name: cluster1

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ns-cluster2.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ns-cluster2.yaml
@@ -22,7 +22,7 @@ spec:
         # You get the repo key from your Solo Account Representative.
         hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
         # The Solo.io Gloo Istio tag
-        tag: 1.22.3-patch1-solo
+        tag: 1.23.0-solo
         values:
           gateways:
             istio-ingressgateway:

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ns-cluster2.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ns-cluster2.yaml
@@ -8,8 +8,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "-7"
 spec:
   installations:
-      # The revision for this installation, such as 1-22
-    - gatewayRevision: 1-22
+      # The revision for this installation, such as 1-23
+    - gatewayRevision: 1-23
       # List all workload clusters to install Istio into
       clusters:
       - name: cluster2

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ns-mgmt.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ns-mgmt.yaml
@@ -22,7 +22,7 @@ spec:
         # You get the repo key from your Solo Account Representative.
         hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
         # The Solo.io Gloo Istio tag
-        tag: 1.22.3-patch1-solo
+        tag: 1.23.0-solo
         values:
           gateways:
             istio-ingressgateway:

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ns-mgmt.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/glcm-ns-mgmt.yaml
@@ -8,8 +8,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "-7"
 spec:
   installations:
-      # The revision for this installation, such as 1-22
-    - gatewayRevision: 1-22
+      # The revision for this installation, such as 1-23
+    - gatewayRevision: 1-23
       # List all workload clusters to install Istio into
       clusters:
       - name: mgmt

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/grafana-helm.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/grafana-helm.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/ilcm-cluster1.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/ilcm-cluster1.yaml
@@ -22,7 +22,7 @@ spec:
         # You get the repo key from your Solo Account Representative.
         hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
         # Any Solo.io Gloo Istio tag
-        tag: 1.22.3-patch1-solo
+        tag: 1.23.0-solo
         namespace: istio-system
         # Mesh configuration
         meshConfig:

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/ilcm-cluster1.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/ilcm-cluster1.yaml
@@ -7,8 +7,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "-8"
 spec:
   installations:
-      # The revision for this installation, such as 1-22
-    - revision: 1-22
+      # The revision for this installation, such as 1-23
+    - revision: 1-23
       # List all workload clusters to install Istio into
       clusters:
       - name: cluster1

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/ilcm-cluster2.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/ilcm-cluster2.yaml
@@ -22,7 +22,7 @@ spec:
         # You get the repo key from your Solo Account Representative.
         hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
         # Any Solo.io Gloo Istio tag
-        tag: 1.22.3-patch1-solo
+        tag: 1.23.0-solo
         namespace: istio-system
         # Mesh configuration
         meshConfig:

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/ilcm-cluster2.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/ilcm-cluster2.yaml
@@ -7,8 +7,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "-8"
 spec:
   installations:
-      # The revision for this installation, such as 1-22
-    - revision: 1-22
+      # The revision for this installation, such as 1-23
+    - revision: 1-23
       # List all workload clusters to install Istio into
       clusters:
       - name: cluster2

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/ilcm-mgmt.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/ilcm-mgmt.yaml
@@ -7,8 +7,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "-8"
 spec:
   installations:
-      # The revision for this installation, such as 1-22
-    - revision: 1-22
+      # The revision for this installation, such as 1-23
+    - revision: 1-23
       # List all workload clusters to install Istio into
       clusters:
       - name: mgmt

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/ilcm-mgmt.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/ilcm-mgmt.yaml
@@ -28,7 +28,7 @@ spec:
         # You get the repo key from your Solo Account Representative.
         hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
         # Any Solo.io Gloo Istio tag
-        tag: 1.22.3-patch1-solo
+        tag: 1.23.0-solo
         namespace: istio-system
         # Mesh configuration
         meshConfig:

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/istio-eastwestgateway-svc.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/base/istio-eastwestgateway-svc.yaml
@@ -4,12 +4,12 @@ metadata:
   labels:
     app: istio-ingressgateway
     istio: eastwestgateway
-    revision: 1-22
+    revision: 1-23
     topology.istio.io/network: mgmt
   annotations:
     # AWS NLB Annotation
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-  name: istio-eastwestgateway-1-22
+  name: istio-eastwestgateway-1-23
   namespace: istio-gateways
 spec:
   ports:
@@ -36,6 +36,6 @@ spec:
   selector:
     app: istio-ingressgateway
     istio: eastwestgateway
-    revision: 1-22
+    revision: 1-23
     topology.istio.io/network: mgmt
   type: LoadBalancer

--- a/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/test.sh
+++ b/environments/gloo-platform/core/mgmt/istio/lifecyclemanager/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
-#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-22 istio-eastwest 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
+#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-23 istio-eastwest 10 ${cluster_context}

--- a/environments/gloo-platform/core/shared-components/clusterconfig/base/gloo-mesh-addons-ns.yaml
+++ b/environments/gloo-platform/core/shared-components/clusterconfig/base/gloo-mesh-addons-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: gloo-mesh-addons
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-platform/core/shared-components/clusterconfig/base/gloo-mesh-ns.yaml
+++ b/environments/gloo-platform/core/shared-components/clusterconfig/base/gloo-mesh-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: gloo-mesh
   #labels:
-  #  istio.io/rev: 1-22
+  #  istio.io/rev: 1-23

--- a/environments/gloo-platform/core/shared-components/clusterconfig/base/httpbin-ns.yaml
+++ b/environments/gloo-platform/core/shared-components/clusterconfig/base/httpbin-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: httpbin
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-platform/core/shared-components/clusterconfig/base/istio-eastwest-ns.yaml
+++ b/environments/gloo-platform/core/shared-components/clusterconfig/base/istio-eastwest-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: istio-eastwest
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-platform/core/shared-components/clusterconfig/base/istio-gateways-ns.yaml
+++ b/environments/gloo-platform/core/shared-components/clusterconfig/base/istio-gateways-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: istio-gateways
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/grafana.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/grafana.yaml
@@ -126,7 +126,7 @@ spec:
         app.kubernetes.io/instance: grafana
         app: grafana
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
         checksum/config: 0db0166dec9b75eb6486494512ab843bc085e0806457bc09e92597a418a115ae

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/istio-ingressgateway.yaml
@@ -19,9 +19,9 @@ spec:
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
-        name: "istio-ingressgateway-1-22"
+        name: "istio-ingressgateway-1-23"
         # revision declares which revision this gateway is a part of
-        revision: "1-22"
+        revision: "1-23"
         
         replicaCount: 1
         

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           trustDomain: cluster1
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/core/shared-components/istio/helm/test.sh
+++ b/environments/gloo-platform/core/shared-components/istio/helm/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
 #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}

--- a/environments/gloo-platform/core/shared-components/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/tracing/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-platform/core/shared-components/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/tracing/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/core/shared-components/istio/lifecyclemanager/base/grafana.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/lifecyclemanager/base/grafana.yaml
@@ -126,7 +126,7 @@ spec:
         app.kubernetes.io/instance: grafana
         app: grafana
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
         checksum/config: 0db0166dec9b75eb6486494512ab843bc085e0806457bc09e92597a418a115ae

--- a/environments/gloo-platform/core/shared-components/istio/lifecyclemanager/base/istio-ingressgateway-svc.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/lifecyclemanager/base/istio-ingressgateway-svc.yaml
@@ -4,11 +4,11 @@ metadata:
   labels:
     app: istio-ingressgateway
     istio: ingressgateway
-    revision: 1-22
+    revision: 1-23
   annotations:
     # AWS NLB Annotation
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-  name: istio-ingressgateway-1-22
+  name: istio-ingressgateway-1-23
   namespace: istio-gateways
 spec:
   ports:
@@ -23,5 +23,5 @@ spec:
   selector:
     app: istio-ingressgateway
     istio: ingressgateway
-    revision: 1-22
+    revision: 1-23
   type: LoadBalancer

--- a/environments/gloo-platform/core/shared-components/istio/lifecyclemanager/test.sh
+++ b/environments/gloo-platform/core/shared-components/istio/lifecyclemanager/test.sh
@@ -3,7 +3,7 @@
 if [ "${environment_overlay}" == "ilcm" ] ; then 
      echo ""
   else 
-     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
      #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}
   fi
 

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/README.md
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/README.md
@@ -11,11 +11,11 @@ The `gloo-platform/core/cluster1` environment deploys the `cluster1` worker for 
 ## Environment description
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilcm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILCM)
+    - istio 1.23.0-solo (ILCM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/README.md
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/README.md
@@ -12,11 +12,11 @@ The `gloo-platform/core/cluster1` environment deploys the `cluster1` worker for 
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilcm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILCM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -37,7 +37,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -78,7 +78,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/clusterconfig/base/bookinfo-backends-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/clusterconfig/base/bookinfo-backends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
   name: bookinfo-backends

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/clusterconfig/base/bookinfo-frontends-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/clusterconfig/base/bookinfo-frontends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
   name: bookinfo-frontends

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/gloo-platform/init.sh
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/gloo-platform/init.sh
@@ -120,7 +120,7 @@ spec:
             #service: 
             #  type: ClusterIP
             #podLabels:
-            #  istio.io/rev: 1-22
+            #  istio.io/rev: 1-23
             #podAnnotations:
             #  proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             image:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/httpbin-app/base/httpbin-in-mesh.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/httpbin-app/base/httpbin-in-mesh.yaml
@@ -40,7 +40,7 @@ spec:
       labels:
         app: in-mesh
         version: v1
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     spec:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/grafana-helm.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/grafana-helm.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istio-eastwestgateway.yaml
@@ -21,7 +21,7 @@ spec:
         # Name allows overriding the release name. Generally this should not be set
         name: "istio-eastwestgateway"
         # revision declares which revision this gateway is a part of
-        revision: "1-22"
+        revision: "1-23"
         
         replicaCount: 1
         
@@ -55,7 +55,7 @@ spec:
         
         # Labels to apply to all resources
         labels:
-          istio.io/rev: 1-22
+          istio.io/rev: 1-23
           istio: eastwestgateway
           topology.istio.io/network: cluster1
   syncPolicy:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istio-eastwestgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: cluster1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           trustDomain: cluster1
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/test.sh
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/test.sh
@@ -3,7 +3,7 @@
 if [ "${environment_overlay}" == "ilcm" ] ; then 
      echo ""
   else 
-     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
      #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}
   fi
 

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/tracing/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: cluster1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/tracing/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/lifecyclemanager/base/grafana-helm.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/lifecyclemanager/base/grafana-helm.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/lifecyclemanager/base/istio-eastwestgateway-svc.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/lifecyclemanager/base/istio-eastwestgateway-svc.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: istio-ingressgateway
     istio: eastwestgateway
-    revision: 1-22
+    revision: 1-23
     topology.istio.io/network: cluster1
   annotations:
     # AWS NLB Annotation
@@ -36,6 +36,6 @@ spec:
   selector:
     app: istio-ingressgateway
     istio: eastwestgateway
-    revision: 1-22
+    revision: 1-23
     topology.istio.io/network: cluster1
   type: LoadBalancer

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/lifecyclemanager/test.sh
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/lifecyclemanager/test.sh
@@ -3,7 +3,7 @@
 if [ "${environment_overlay}" == "ilcm" ] ; then 
      echo ""
   else 
-     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
      #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}
   fi
 

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/README.md
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/README.md
@@ -11,11 +11,11 @@ The `gloo-platform/core/cluster2` environment deploys the `cluster2` worker for 
 ## Environment description
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilcm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILCM)
+    - istio 1.23.0-solo (ILCM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/README.md
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/README.md
@@ -12,11 +12,11 @@ The `gloo-platform/core/cluster2` environment deploys the `cluster2` worker for 
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilcm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILCM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -37,7 +37,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -78,7 +78,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/clusterconfig/base/bookinfo-backends-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/clusterconfig/base/bookinfo-backends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
   name: bookinfo-backends

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/clusterconfig/base/bookinfo-frontends-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/clusterconfig/base/bookinfo-frontends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
   name: bookinfo-frontends

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/gloo-platform/init.sh
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/gloo-platform/init.sh
@@ -120,7 +120,7 @@ spec:
             #service: 
             #  type: ClusterIP
             #podLabels:
-            #  istio.io/rev: 1-22
+            #  istio.io/rev: 1-23
             #podAnnotations:
             #  proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             image:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/httpbin-app/base/httpbin-in-mesh.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/httpbin-app/base/httpbin-in-mesh.yaml
@@ -39,7 +39,7 @@ spec:
       labels:
         app: in-mesh
         version: v3
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     spec:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/grafana-helm.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/grafana-helm.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istio-eastwestgateway.yaml
@@ -21,7 +21,7 @@ spec:
         # Name allows overriding the release name. Generally this should not be set
         name: "istio-eastwestgateway"
         # revision declares which revision this gateway is a part of
-        revision: "1-22"
+        revision: "1-23"
         
         replicaCount: 1
         
@@ -55,7 +55,7 @@ spec:
         
         # Labels to apply to all resources
         labels:
-          istio.io/rev: 1-22
+          istio.io/rev: 1-23
           istio: eastwestgateway
           topology.istio.io/network: cluster2
   syncPolicy:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istio-eastwestgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster2
           network: cluster2
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           trustDomain: cluster2
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/test.sh
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/test.sh
@@ -3,7 +3,7 @@
 if [ "${environment_overlay}" == "ilcm" ] ; then 
      echo ""
   else 
-     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
      #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}
   fi
 

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/tracing/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster2
           network: cluster2
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/tracing/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/lifecyclemanager/base/grafana-helm.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/lifecyclemanager/base/grafana-helm.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/lifecyclemanager/base/istio-eastwestgateway-svc.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/lifecyclemanager/base/istio-eastwestgateway-svc.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: istio-ingressgateway
     istio: eastwestgateway
-    revision: 1-22
+    revision: 1-23
     topology.istio.io/network: cluster2
   annotations:
     # AWS NLB Annotation
@@ -36,6 +36,6 @@ spec:
   selector:
     app: istio-ingressgateway
     istio: eastwestgateway
-    revision: 1-22
+    revision: 1-23
     topology.istio.io/network: cluster2
   type: LoadBalancer

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/lifecyclemanager/test.sh
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/lifecyclemanager/test.sh
@@ -3,7 +3,7 @@
 if [ "${environment_overlay}" == "ilcm" ] ; then 
      echo ""
   else 
-     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
      #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}
   fi
 

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/README.md
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/README.md
@@ -19,11 +19,11 @@ When applied with `cluster1` and `cluster2` environments, here is a high level d
 ## Environment description
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilcm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILCM)
+    - istio 1.23.0-solo (ILCM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/README.md
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/README.md
@@ -20,11 +20,11 @@ When applied with `cluster1` and `cluster2` environments, here is a high level d
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilcm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILCM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -45,7 +45,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -86,7 +86,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform/base/gloo-platform-helm.yaml
@@ -63,7 +63,7 @@ spec:
             #                annotations:
             #                    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             #                labels:
-            #                    istio.io/rev: 1-22
+            #                    istio.io/rev: 1-23
             #                    sidecar.istio.io/inject: "true"
             enabled: true
             serviceType: ClusterIP
@@ -96,7 +96,7 @@ spec:
             #service: 
             #    type: ClusterIP
             #podLabels:
-            #    istio.io/rev: 1-22
+            #    istio.io/rev: 1-23
             #podAnnotations:
             #    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             image:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/gloo-mesh-addons-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/gloo-mesh-addons-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: gloo-mesh-addons
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/gloo-mesh-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/gloo-mesh-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: gloo-mesh
   #labels:
-  #  istio.io/rev: 1-22
+  #  istio.io/rev: 1-23

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/httpbin-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/httpbin-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: httpbin
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/istio-eastwest-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/istio-eastwest-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: istio-eastwest
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/istio-gateways-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/istio-gateways-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: istio-gateways
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/grafana.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/grafana.yaml
@@ -126,7 +126,7 @@ spec:
         app.kubernetes.io/instance: grafana
         app: grafana
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
         checksum/config: 0db0166dec9b75eb6486494512ab843bc085e0806457bc09e92597a418a115ae

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istio-ingressgateway.yaml
@@ -19,9 +19,9 @@ spec:
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
-        name: "istio-ingressgateway-1-22"
+        name: "istio-ingressgateway-1-23"
         # revision declares which revision this gateway is a part of
-        revision: "1-22"
+        revision: "1-23"
         
         replicaCount: 1
         

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           trustDomain: cluster1
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/test.sh
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
 #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/tracing/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         global:
           meshID: mesh1
           multiCluster:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/tracing/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.22.3-patch1-solo
+          tag: 1.23.0-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/lifecyclemanager/base/grafana.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/lifecyclemanager/base/grafana.yaml
@@ -126,7 +126,7 @@ spec:
         app.kubernetes.io/instance: grafana
         app: grafana
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
         checksum/config: 0db0166dec9b75eb6486494512ab843bc085e0806457bc09e92597a418a115ae

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/lifecyclemanager/base/istio-ingressgateway-svc.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/lifecyclemanager/base/istio-ingressgateway-svc.yaml
@@ -4,11 +4,11 @@ metadata:
   labels:
     app: istio-ingressgateway
     istio: ingressgateway
-    revision: 1-22
+    revision: 1-23
   annotations:
     # AWS NLB Annotation
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-  name: istio-ingressgateway-1-22
+  name: istio-ingressgateway-1-23
   namespace: istio-gateways
 spec:
   ports:
@@ -23,5 +23,5 @@ spec:
   selector:
     app: istio-ingressgateway
     istio: ingressgateway
-    revision: 1-22
+    revision: 1-23
   type: LoadBalancer

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/lifecyclemanager/test.sh
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/lifecyclemanager/test.sh
@@ -3,7 +3,7 @@
 if [ "${environment_overlay}" == "ilcm" ] ; then 
      echo ""
   else 
-     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-22 istio-gateways 10 ${cluster_context}
+     $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
      #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}
   fi
 

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster1/httpbin-app/base/httpbin-in-mesh.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster1/httpbin-app/base/httpbin-in-mesh.yaml
@@ -40,7 +40,7 @@ spec:
       labels:
         app: in-mesh
         version: v1
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     spec:

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster2/httpbin-app/base/httpbin-in-mesh.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster2/httpbin-app/base/httpbin-in-mesh.yaml
@@ -39,7 +39,7 @@ spec:
       labels:
         app: in-mesh
         version: v3
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     spec:

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/README.md
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/README.md
@@ -18,11 +18,11 @@ When applied with `cluster1` and `cluster2` environments, here is a high level d
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilcm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILCM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -55,7 +55,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -96,7 +96,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/README.md
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/README.md
@@ -17,11 +17,11 @@ When applied with `cluster1` and `cluster2` environments, here is a high level d
 ## Environment description
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilcm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILCM)
+    - istio 1.23.0-solo (ILCM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-app/base/httpbin-in-mesh.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-app/base/httpbin-in-mesh.yaml
@@ -40,7 +40,7 @@ spec:
       labels:
         app: in-mesh
         version: v1
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     spec:

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster1/online-boutique-app/base/backend-apis-ns.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster1/online-boutique-app/base/backend-apis-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: backend-apis
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster1/online-boutique-app/base/web-ui-ns.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster1/online-boutique-app/base/web-ui-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: web-ui
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster2/online-boutique-app/base/backend-apis-ns.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster2/online-boutique-app/base/backend-apis-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: backend-apis
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster2/online-boutique-app/base/web-ui-ns.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster2/online-boutique-app/base/web-ui-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: web-ui
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/cluster1/podinfo-app/base/podinfo-ns.yaml
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/cluster1/podinfo-app/base/podinfo-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
   name: podinfo

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/cluster2/podinfo-app/base/podinfo-ns.yaml
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/cluster2/podinfo-app/base/podinfo-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
   name: podinfo

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/README.md
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/README.md
@@ -18,11 +18,11 @@ When applied with `cluster1` and `cluster2` environments, here is a high level d
 - base:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (Helm)
-    - revision: 1-22
+    - revision: 1-23
 - ilcm:
     - gloo mesh 2.6.0
     - istio 1.23.0-solo (ILCM)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 
@@ -51,7 +51,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.status.loadBalancer.ingress[0].*}')
 
 echo ${GATEWAY_IP}
@@ -92,7 +92,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-22
+ISTIO_REVISION=1-23
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/README.md
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/README.md
@@ -17,11 +17,11 @@ When applied with `cluster1` and `cluster2` environments, here is a high level d
 ## Environment description
 - base:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (Helm)
+    - istio 1.23.0-solo (Helm)
     - revision: 1-22
 - ilcm:
     - gloo mesh 2.6.0
-    - istio 1.22.3-patch1-solo (ILCM)
+    - istio 1.23.0-solo (ILCM)
     - revision: 1-22
 
 ## Application description

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---

--- a/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-podinfo-weighted-subset-failover/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-base.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-cni.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-cni.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: cni
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         profile: ambient

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-ingressgateway.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-ztunnel.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-ztunnel.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: ztunnel
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/istio/ambient-demo/core/istio/ambient/istiod.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         profile: ambient

--- a/environments/istio/ambient-demo/core/istio/gke/istio-cni.yaml
+++ b/environments/istio/ambient-demo/core/istio/gke/istio-cni.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: cni
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         profile: ambient

--- a/environments/istio/ambient-demo/core/istio/gke/istio-ztunnel.yaml
+++ b/environments/istio/ambient-demo/core/istio/gke/istio-ztunnel.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: ztunnel
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/istio/basic-demo/README.md
+++ b/environments/istio/basic-demo/README.md
@@ -11,7 +11,7 @@ The `istio/basic-demo` environment deploys cert-manager, Istio (with revisions),
 ## Environment description
 - base:
     - istio 1.23.0 (Helm)
-    - revision: 1-22
+    - revision: 1-23
 
 ## Application description
 

--- a/environments/istio/basic-demo/README.md
+++ b/environments/istio/basic-demo/README.md
@@ -10,7 +10,7 @@ The `istio/basic-demo` environment deploys cert-manager, Istio (with revisions),
 
 ## Environment description
 - base:
-    - istio 1.22.3 (Helm)
+    - istio 1.23.0 (Helm)
     - revision: 1-22
 
 ## Application description

--- a/environments/istio/basic-demo/homer/base/homer-portal-ns.yaml
+++ b/environments/istio/basic-demo/homer/base/homer-portal-ns.yaml
@@ -3,6 +3,6 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
   annotations:
     argocd.argoproj.io/sync-wave: "-5"

--- a/environments/istio/basic-demo/homer/base/homer-portal.yaml
+++ b/environments/istio/basic-demo/homer/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-22
+        #  istio.io/rev: 1-23
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/istio/basic-demo/homer/lb-discovery/homer-portal-ns.yaml
+++ b/environments/istio/basic-demo/homer/lb-discovery/homer-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23

--- a/environments/istio/basic-demo/homer/lb-discovery/init.sh
+++ b/environments/istio/basic-demo/homer/lb-discovery/init.sh
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/environments/istio/basic-demo/httpbin/base/httpbin-ns.yaml
+++ b/environments/istio/basic-demo/httpbin/base/httpbin-ns.yaml
@@ -3,6 +3,6 @@ kind: Namespace
 metadata:
   name: httpbin
   labels:
-    istio.io/rev: 1-22
+    istio.io/rev: 1-23
   annotations:
     argocd.argoproj.io/sync-wave: "-5"

--- a/environments/istio/basic-demo/istio/base/istio-base.yaml
+++ b/environments/istio/basic-demo/istio/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/istio/basic-demo/istio/base/istio-ingressgateway.yaml
+++ b/environments/istio/basic-demo/istio/base/istio-ingressgateway.yaml
@@ -21,7 +21,7 @@ spec:
         # Name allows overriding the release name. Generally this should not be set
         name: ""
         # revision declares which revision this gateway is a part of
-        revision: "1-22"
+        revision: "1-23"
         
         replicaCount: 1
         

--- a/environments/istio/basic-demo/istio/base/istio-ingressgateway.yaml
+++ b/environments/istio/basic-demo/istio/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/istio/basic-demo/istio/base/istiod.yaml
+++ b/environments/istio/basic-demo/istio/base/istiod.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: 1.23.0
     helm:
       values: |
-        revision: 1-22
+        revision: 1-23
         meshConfig:
           accessLogFile: /dev/stdout
           enableAutoMtls: true

--- a/environments/istio/basic-demo/istio/base/istiod.yaml
+++ b/environments/istio/basic-demo/istio/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.22.3
+    targetRevision: 1.23.0
     helm:
       values: |
         revision: 1-22

--- a/environments/istio/basic-demo/istio/base/kiali.yaml
+++ b/environments/istio/basic-demo/istio/base/kiali.yaml
@@ -74,7 +74,7 @@ data:
       pod_annotations: {}
       pod_labels:
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-22
+        istio.io/rev: 1-23
       priority_class_name: ""
       replicas: 1
       resources:
@@ -116,9 +116,9 @@ data:
         url: http://prometheus:9090/prometheus
       ### add the following if using revisioned based istio installation
       istio:
-        config_map_name: istio-1-22
-        istio_sidecar_injector_config_map_name: istio-sidecar-injector-1-22
-        istiod_deployment_name: istiod-1-22
+        config_map_name: istio-1-23
+        istio_sidecar_injector_config_map_name: istio-sidecar-injector-1-23
+        istiod_deployment_name: istiod-1-23
         root_namespace: istio-system
     identity:
       cert_file: ""

--- a/environments/istio/basic-demo/istio/test.sh
+++ b/environments/istio/basic-demo/istio/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway istio-system 10 ${cluster_context}
-#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-22 istio-eastwest 10 ${cluster_context}
+#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-23 istio-eastwest 10 ${cluster_context}


### PR DESCRIPTION
0.5.1 (8-19-24)
---
- update istio helm chart version to `1.23.0-solo` and revision label `1-23` across all environments