### PR TITLE
see CHANGELOG (0.5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+0.5.4 (8-30-24)
+---
+- set `featureGates.insightsConfiguration=true` helm values and configure an `InsightsConfig` to disable to supress `HLT0001` insight when using Gloo Gateway Istio integration feature in `gateway-api/with-gm-istio` and `gloo-platform/gwapi-mgmt-gm-workers` environments
+
 0.5.3 (8-29-24)
 ---
 - update gloo-edge/gateway-api environments to 1.17.1

--- a/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform-config/base/disabled-insights.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform-config/base/disabled-insights.yaml
@@ -1,0 +1,8 @@
+apiVersion: admin.gloo.solo.io/v2alpha1
+kind: InsightsConfig
+metadata:
+  name: insights-config
+  namespace: gloo-mesh
+spec:
+  disabledInsights:
+    - HLT0001

--- a/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform-config/base/disabled-insights.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform-config/base/disabled-insights.yaml
@@ -1,7 +1,7 @@
 apiVersion: admin.gloo.solo.io/v2alpha1
 kind: InsightsConfig
 metadata:
-  name: insights-config
+  name: disabled-insights
   namespace: gloo-mesh
 spec:
   disabledInsights:

--- a/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform-config/base/disabled-insights.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform-config/base/disabled-insights.yaml
@@ -6,4 +6,3 @@ metadata:
 spec:
   disabledInsights:
     - HLT0001
-    - CFG0014

--- a/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform-config/base/disabled-insights.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform-config/base/disabled-insights.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   disabledInsights:
     - HLT0001
-    #- CFG0014
+    - CFG0014

--- a/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform-config/base/disabled-insights.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform-config/base/disabled-insights.yaml
@@ -6,3 +6,4 @@ metadata:
 spec:
   disabledInsights:
     - HLT0001
+    - CFG0014

--- a/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform-config/base/disabled-insights.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform-config/base/disabled-insights.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   disabledInsights:
     - HLT0001
-    - CFG0014
+    #- CFG0014

--- a/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform-config/base/kustomization.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform-config/base/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
 #- roottrustpolicy-generated.yaml
 #- roottrustpolicy-secretref.yaml
 - gloo-mesh-ui-https.yaml
+- disabled-insights.yaml

--- a/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform/base/gloo-platform-crds.yaml
@@ -12,6 +12,10 @@ spec:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
     targetRevision: 2.6.0
+    helm:
+      values: |
+        featureGates:
+          insightsConfiguration: true
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform/base/gloo-platform-crds.yaml
@@ -12,10 +12,10 @@ spec:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
     targetRevision: 2.6.0
-    #helm:
-    #  values: |
-    #    featureGates:
-    #      insightsConfiguration: true
+    helm:
+      values: |
+        featureGates:
+          insightsConfiguration: true
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform/base/gloo-platform-crds.yaml
@@ -12,10 +12,10 @@ spec:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
     targetRevision: 2.6.0
-    helm:
-      values: |
-        featureGates:
-          insightsConfiguration: true
+    #helm:
+    #  values: |
+    #    featureGates:
+    #      insightsConfiguration: true
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-edge/gateway-api/with-gm-istio/gloo-platform/base/gloo-platform-helm.yaml
@@ -15,6 +15,8 @@ spec:
     helm:
       skipCrds: true
       values: |
+        featureGates:
+            insightsConfiguration: true
         common:
             addonNamespace: "gloo-mesh-addons"
             adminNamespace: "gloo-mesh"

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform-config/base/disabled-insights.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform-config/base/disabled-insights.yaml
@@ -1,0 +1,8 @@
+apiVersion: admin.gloo.solo.io/v2alpha1
+kind: InsightsConfig
+metadata:
+  name: disabled-insights
+  namespace: gloo-mesh
+spec:
+  disabledInsights:
+    - HLT0001

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform-config/base/kustomization.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform-config/base/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
 - workload-vg-443.yaml
 - argocd-cluster1-rt-443.yaml
 - argocd-cluster2-rt-443.yaml
+- disabled-insights.yaml

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform/base/gloo-platform-crds.yaml
@@ -12,6 +12,10 @@ spec:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
     targetRevision: 2.6.0
+    helm:
+      values: |
+        featureGates:
+          insightsConfiguration: true
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform/base/gloo-platform-helm.yaml
@@ -15,6 +15,8 @@ spec:
     helm:
       skipCrds: true
       values: |
+        featureGates:
+            insightsConfiguration: true
         common:
             addonNamespace: "gloo-mesh-addons"
             adminNamespace: "gloo-mesh"


### PR DESCRIPTION
0.5.4 (8-30-24)
---
- set `featureGates.insightsConfiguration=true` helm values and configure an `InsightsConfig` to disable to supress `HLT0001` insight when using Gloo Gateway Istio integration feature in `gateway-api/with-gm-istio` and `gloo-platform/gwapi-mgmt-gm-workers` environments