### PR TITLE
see CHANGELOG (0.5.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+0.5.6 (9-5-24)
+---
+- add `tracks-route-policies` to disable JWT validation at the route level in the `gateway-api/portal-only` environment
+- add `petstore-api` example to `gateway-api/portal-only` environment. this is not configured by default, but is numbered so that a user can walk through the steps of onboarding an API product manually by applying the manifests in ordered stages 1 > 2 > 3 > 4 while describing the workflow
+
 0.5.5 (9-4-24)
 ---
 - set `gloo-fed.enabled=false` and `gloo-fed.glooFedApiserver.enable=false` in gateway-api environments since they are unused

--- a/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/kustomization.yaml
+++ b/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/kustomization.yaml
@@ -6,3 +6,4 @@ kind: Kustomization
 resources:
 - solo-dev-portal
 - tracks-api
+#- petstore-api

--- a/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/1-pets-api.yaml
+++ b/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/1-pets-api.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pets
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: pets-rest-api
+    demo: portal
+  name: pets-rest-api
+  namespace: pets
+spec:
+  selector:
+    matchLabels:
+      app: pets-rest-api
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: pets-rest-api
+    spec:
+      containers:
+      - image: gcr.io/solo-public/docs/pets-rest-api:latest
+        name: pets-rest-api
+        ports:
+        - containerPort: 5000
+          name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    gloo.solo.io/scrape-openapi-source: /swagger.json
+    gloo.solo.io/scrape-openapi-retry-delay: "30s"
+    gloo.solo.io/scrape-openapi-pull-attempts: "3"
+    gloo.solo.io/scrape-openapi-use-backoff: "true"
+  name: pets-rest-api
+  namespace: pets
+  labels:
+    app: pets-rest-api
+    demo: portal
+spec:
+  ports:
+  - port: 5000
+    protocol: TCP
+  selector:
+    app: pets-rest-api

--- a/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/1-store-api.yaml
+++ b/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/1-store-api.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: store
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: store-rest-api
+    demo: portal
+  name: store-rest-api
+  namespace: store
+spec:
+  selector:
+    matchLabels:
+      app: store-rest-api
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: store-rest-api
+    spec:
+      containers:
+      - image: gcr.io/solo-public/docs/store-rest-api:latest
+        name: store-rest-api
+        ports:
+        - containerPort: 5000
+          name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    gloo.solo.io/scrape-openapi-source: /swagger.json
+    gloo.solo.io/scrape-openapi-retry-delay: "30s"
+    gloo.solo.io/scrape-openapi-pull-attempts: "3"
+    gloo.solo.io/scrape-openapi-use-backoff: "true"
+  name: store-rest-api
+  namespace: store
+  labels:
+    app: store-rest-api
+    demo: portal
+spec:
+  ports:
+  - port: 5000
+    protocol: TCP
+  selector:
+    app: store-rest-api

--- a/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/1-users-api.yaml
+++ b/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/1-users-api.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: users
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: users-rest-api
+    demo: portal
+  name: users-rest-api
+  namespace: users
+spec:
+  selector:
+    matchLabels:
+      app: users-rest-api
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: users-rest-api
+    spec:
+      containers:
+      - image: gcr.io/solo-public/docs/users-rest-api:latest
+        name: users-rest-api
+        ports:
+        - containerPort: 5000
+          name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    gloo.solo.io/scrape-openapi-source: /swagger.json
+    gloo.solo.io/scrape-openapi-retry-delay: "30s"
+    gloo.solo.io/scrape-openapi-pull-attempts: "3"
+    gloo.solo.io/scrape-openapi-use-backoff: "true"
+  name: users-rest-api
+  namespace: users
+  labels:
+    app: users-rest-api
+    demo: portal
+spec:
+  ports:
+  - port: 5000
+    protocol: TCP
+  selector:
+    app: users-rest-api

--- a/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/2-petstore-route-policies.yaml
+++ b/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/2-petstore-route-policies.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.solo.io/v1
+kind: RouteOption
+metadata:
+  name: petstore-route-policies
+  namespace: gloo-system
+spec:
+  options:
+    jwt:
+      disable: true
+                
+                
+    

--- a/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/2-petstore-route.yaml
+++ b/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/2-petstore-route.yaml
@@ -1,0 +1,80 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: petstore-route
+  namespace: gloo-system
+spec:
+  hostnames:
+    - petstore.glootest.com
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: https
+      namespace: gloo-system
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: users-rest-api
+          namespace: users
+          port: 5000
+          weight: 1
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              replacePrefixMatch: /
+              type: ReplacePrefixMatch
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.solo.io
+            kind: RouteOption
+            name: portal-backend-route-policies
+      matches:
+        - path:
+            type: PathPrefix
+            value: /users
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: pets-rest-api
+          namespace: pets
+          port: 5000
+          weight: 1
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              replacePrefixMatch: /
+              type: ReplacePrefixMatch
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.solo.io
+            kind: RouteOption
+            name: portal-backend-route-policies
+      matches:
+        - path:
+            type: PathPrefix
+            value: /pets
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: store-rest-api
+          namespace: store
+          port: 5000
+          weight: 1
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              replacePrefixMatch: /
+              type: ReplacePrefixMatch
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.solo.io
+            kind: RouteOption
+            name: portal-backend-route-policies
+      matches:
+        - path:
+            type: PathPrefix
+            value: /store

--- a/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/3-refgrants.yaml
+++ b/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/3-refgrants.yaml
@@ -1,0 +1,41 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: pets-rg
+  namespace: pets
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: gloo-system
+  to:
+    - group: ""
+      kind: Service
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: users-rg
+  namespace: users
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: gloo-system
+  to:
+    - group: ""
+      kind: Service
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: store-rg
+  namespace: store
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: gloo-system
+  to:
+    - group: ""
+      kind: Service

--- a/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/4-api-product.yaml
+++ b/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/4-api-product.yaml
@@ -1,0 +1,28 @@
+apiVersion: portal.gloo.solo.io/v1
+kind: ApiProduct
+metadata:
+  labels:
+    expose-portal: "true"
+  name: petstore-svc-api-product
+  namespace: gloo-system
+spec:
+  id: "petstore"
+  displayName: "Pet Store"
+  customMetadata:
+    imageURL: https://raw.githubusercontent.com/solo-io/gloo/8d9df95602c506067d49db9b1447b4003b19a070/docs/content/img/portal/petstore-food-bowl-collar.png
+  versions:
+  - apiVersion: "v1"
+    openapiMetadata:
+      title: "Pet Store REST API v1"
+      description: "Totally awesome API for all things pets!"
+      termsOfService: "You must authenticate to use this API! And other Terms of Service."
+      contact: "support@example.com"
+      license: "License info, such as MIT"
+    customMetadata:
+      compatibility: "None"
+      lifecyclePhase: "Generally Available"
+    targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: petstore-route
+      namespace: gloo-system

--- a/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/kustomization.yaml
+++ b/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/petstore-api/kustomization.yaml
@@ -1,0 +1,13 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# list of resources to be Applied
+resources:
+- 1-pets-api.yaml
+- 1-store-api.yaml
+- 1-users-api.yaml
+- 2-petstore-route-policies.yaml
+- 2-petstore-route.yaml
+- 3-refgrants.yaml
+- 4-api-product.yaml

--- a/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/solo-dev-portal/portal-developer.yaml
+++ b/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/solo-dev-portal/portal-developer.yaml
@@ -9,5 +9,5 @@ spec:
   apiProducts:
   - name: tracks-svc-api-product
     namespace: gloo-system
-  - name: gh-actions-idp-svc-api-product
+  - name: petstore-svc-api-product
     namespace: gloo-system

--- a/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/tracks-api/tracks-route-policies.yaml
+++ b/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/tracks-api/tracks-route-policies.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.solo.io/v1
+kind: RouteOption
+metadata:
+  name: tracks-route-policies
+  namespace: gloo-system
+spec:
+  options:
+    jwt:
+      disable: true
+                
+                
+    

--- a/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/tracks-api/tracks-route.yaml
+++ b/environments/gloo-edge/gateway-api/portal-only/gloo-portal-demo/base/tracks-api/tracks-route.yaml
@@ -35,3 +35,8 @@ spec:
             group: gateway.solo.io
             kind: RouteOption
             name: tracks-cors
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.solo.io
+            kind: RouteOption
+            name: portal-backend-route-policies


### PR DESCRIPTION
0.5.6 (9-5-24)
---
- add `tracks-route-policies` to disable JWT validation at the route level in the `gateway-api/portal-only` environment
- add `petstore-api` example to `gateway-api/portal-only` environment. this is not configured by default, but is numbered so that a user can walk through the steps of onboarding an API product manually by applying the manifests in ordered stages 1 > 2 > 3 > 4 while describing the workflow