### PR TITLE
see CHANGELOG (0.5.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+0.5.7 (9-9-24)
+---
+- remove reference to gloo portal in homer dashboard for gateway-api/standalone environment - moved to gateway-api/portal-only
+- fix duplicate `-solo` istio image tag reference in gloo-gateway/core environment
+
 0.5.6 (9-5-24)
 ---
 - add `tracks-route-policies` to disable JWT validation at the route level in the `gateway-api/portal-only` environment

--- a/environments/gloo-edge/gateway-api/standalone/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-edge/gateway-api/standalone/homer-app/base/homer-portal.yaml
@@ -226,15 +226,6 @@ spec:
                         tag: "ai-gateway"
                         url: "https://language-chatbot.glootest.com"
                         target: "_blank" # optional html a tag target attribute
-                  
-                  - name: "Gloo Portal"
-                    icon: "fas fa-cloud"
-                    items:
-                      - name: "React Frontend - Solo Dev Portal"
-                        icon: "fab fa-connectdevelop"
-                        tag: "portal"
-                        url: "https://solo-dev-portal.glootest.com"
-                        target: "_blank" # optional html a tag target attribute
                     
   syncPolicy:
     automated:

--- a/environments/gloo-gateway/core/istio/lifecyclemanager/base/glcm-ns-mgmt.yaml
+++ b/environments/gloo-gateway/core/istio/lifecyclemanager/base/glcm-ns-mgmt.yaml
@@ -22,7 +22,7 @@ spec:
         # You get the repo key from your Solo Account Representative.
         hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
         # The Solo.io Gloo Istio tag
-        tag: 1.23.0-solo-solo
+        tag: 1.23.0-solo
         values:
           gateways:
             istio-ingressgateway:


### PR DESCRIPTION
0.5.7 (9-9-24)
---
- remove reference to gloo portal in homer dashboard for gateway-api/standalone environment - moved to gateway-api/portal-only
- fix duplicate `-solo` istio image tag reference in gloo-gateway/core environment