### PR TITLE
see CHANGELOG (0.6.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+0.6.6 (10-17-24)
+---
+- add `/aoa-tools/render-manifests.sh` script - generate and view all Kubernetes manifests for a given environment or wave by providing a path
+- add `Render environment manifests` section to README.md on how to use this new tool
+
 0.6.5 (10-16-24)
 ---
 - add ability to the to configure sync override for wave in catalog.yaml

--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ Dry-run: Would execute post_deploy script at environments/gloo-gateway/gateway-a
 END.
 ```
 
+### Render environment manifests
+The `render-manifests.sh` script located in `/aoa-tools` allows you to generate and view all Kubernetes manifests for a given environment or wave. It automatically detects all kustomization.yaml files within the specified environment and renders the manifests that will be applied. The output can also be saved to a text file.
+
+Usage:
+```
+./aoa-tools/render-manifests.sh <environment-path>
+```
+
 ### catalog.yaml
 The `catalog.yaml` exists in each demo environment directory which provides a list of app-of-apps "waves" to be deployed in order by the installer. A wave consists of the `location` (relative to the root path of the selected environment) as well as `pre_deploy` and `post_deploy` scripts which can be optionally run which can be useful for tasks such as health checks, or waiting for pods to be ready or printing output.
 

--- a/aoa-tools/render-manifests.sh
+++ b/aoa-tools/render-manifests.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Function to remove trailing slash from a directory path
+remove_trailing_slash() {
+  echo "$1" | sed 's:/*$::'
+}
+
+# Function to print verbose environment details
+print_environment_details() {
+  local env_path="$1"
+  echo "===================================="
+  echo "Processing environment: $env_path"
+  echo "------------------------------------"
+  echo "Date: $(date)"
+  echo "===================================="
+}
+
+# Function to prompt for output file path
+prompt_output_file() {
+  read -p "Would you like to save the output to a file? (y/n): " save_output
+  if [[ "$save_output" == "y" || "$save_output" == "Y" ]]; then
+    read -p "Enter the full path to the output file: " output_file
+  fi
+}
+
+# Check if a path argument was provided
+if [ -z "$1" ]; then
+  echo "Usage: $0 <environment-path>"
+  exit 1
+fi
+
+# Environment path provided as argument
+env_path=$(remove_trailing_slash "$1")  # Normalize the environment path
+
+# Check if the path exists
+if [ ! -d "$env_path" ]; then
+  echo "Error: The provided path '$env_path' does not exist."
+  exit 1
+fi
+
+# Initialize output_file as empty
+output_file=""
+
+# Prompt user for output file path
+prompt_output_file
+
+# Define a function to handle output redirection
+output() {
+  if [ -z "$output_file" ]; then
+    # If no output file, just print to console
+    echo "$1"
+  else
+    # Print to both console and file
+    echo "$1" | tee -a "$output_file"
+  fi
+}
+
+# Print environment details
+output "$(print_environment_details "$env_path")"
+
+# Find all subdirectories with a kustomization.yaml and run kubectl kustomize
+find "$env_path" -type f -name 'kustomization.yaml' | while read -r kustomization_file; do
+  # Normalize the directory path to remove any trailing slashes
+  dir=$(dirname "$kustomization_file" | sed 's:/*$::')
+  
+  output "------------------------------------"
+  output "Found kustomization.yaml in: $dir"
+  output "Running 'kubectl kustomize'..."
+  
+  # Run kubectl kustomize and capture output
+  kubectl_output=$(kubectl kustomize "$dir")
+  
+  if [ $? -ne 0 ]; then
+    output "Error running 'kubectl kustomize' in $dir"
+  else
+    output "Successfully ran 'kubectl kustomize' in $dir"
+    output "------------------------------------"
+    output "Kustomized output for $dir:"
+    output "---"
+    output "$kubectl_output"
+    output "------------------------------------"
+  fi
+done


### PR DESCRIPTION
0.6.6 (10-17-24)
---
- add `/aoa-tools/render-manifests.sh` script - generate and view all Kubernetes manifests for a given environment or wave by providing a path
- add `Render environment manifests` section to README.md on how to use this new tool