### PR TITLE
see CHANGELOG (0.6.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+0.6.9 (10-24-24)
+---
+- Update gloo-gateway to `1.18.0-beta2-bmain-1203aed ` in `gateway-api/1.18/portal-only` and `gateway-api/1.18/ai-gateway` environment
+
 0.6.8 (10-23-24)
 ---
 - Update gloo-gateway to `1.18.0-beta2-bmain-d7eacd4` in `gateway-api/1.18/portal-only` and `gateway-api/1.18/ai-gateway` environment

--- a/environments/gloo-gateway/gateway-api/1.18/ai-gateway/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/ai-gateway/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -95,7 +95,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.0-beta2-bmain-d7eacd4
+    targetRevision: 1.18.0-beta2-bmain-1203aed
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/portal-only/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/portal-only/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -95,7 +95,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: https://storage.googleapis.com/gloo-ee-test-helm
-    targetRevision: 1.18.0-beta2-bmain-d7eacd4
+    targetRevision: 1.18.0-beta2-bmain-1203aed
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).


### PR DESCRIPTION
0.6.9 (10-24-24)
---
- Update gloo-gateway to `1.18.0-beta2-bmain-1203aed ` in `gateway-api/1.18/portal-only` and `gateway-api/1.18/ai-gateway` environment