### PR TITLE
see CHANGELOG (0.6.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+0.6.11 (10-24-24)
+---
+- Update `aoa-tools/render-manifests.sh`. Non-manifest details (environment details, kustomization file locations, etc.) are now prefixed with # to make the output directly usable with kubectl apply.
+
 0.6.10 (10-24-24)
 ---
 - Update `dynamic-rl-script.sh` and `dynamic-rl-script-example-output.txt` in `gateway-api/1.18/portal-only`

--- a/aoa-tools/render-manifests.sh
+++ b/aoa-tools/render-manifests.sh
@@ -8,11 +8,11 @@ remove_trailing_slash() {
 # Function to print verbose environment details
 print_environment_details() {
   local env_path="$1"
-  echo "===================================="
-  echo "Processing environment: $env_path"
-  echo "------------------------------------"
-  echo "Date: $(date)"
-  echo "===================================="
+  echo "# ===================================="
+  echo "# Processing environment: $env_path"
+  echo "# ------------------------------------"
+  echo "# Date: $(date)"
+  echo "# ===================================="
 }
 
 # Function to prompt for output file path
@@ -63,21 +63,22 @@ find "$env_path" -type f -name 'kustomization.yaml' | while read -r kustomizatio
   # Normalize the directory path to remove any trailing slashes
   dir=$(dirname "$kustomization_file" | sed 's:/*$::')
   
-  output "------------------------------------"
-  output "Found kustomization.yaml in: $dir"
-  output "Running 'kubectl kustomize'..."
+  output "# ------------------------------------"
+  output "# Found kustomization.yaml in: $dir"
+  output "# Running 'kubectl kustomize'..."
   
   # Run kubectl kustomize and capture output
   kubectl_output=$(kubectl kustomize "$dir")
   
   if [ $? -ne 0 ]; then
-    output "Error running 'kubectl kustomize' in $dir"
+    output "# Error running 'kubectl kustomize' in $dir"
   else
-    output "Successfully ran 'kubectl kustomize' in $dir"
-    output "------------------------------------"
-    output "Kustomized output for $dir:"
+    output "# Successfully ran 'kubectl kustomize' in $dir"
+    output "# ------------------------------------"
+    output "# Kustomized output for $dir:"
     output "---"
     output "$kubectl_output"
-    output "------------------------------------"
+    output "---"
+    output "# ------------------------------------"
   fi
 done


### PR DESCRIPTION
0.6.11 (10-24-24)
---
- Update `aoa-tools/render-manifests.sh`. Non-manifest details (environment details, kustomization file locations, etc.) are now prefixed with # to make the output directly usable with kubectl apply.