### PR TITLE
see CHANGELOG (0.6.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+0.6.12 (10-30-24)
+---
+- reset 1.18/ai-gateway env to use helm chart from `http://storage.googleapis.com/gloo-ee-helm` and `1.18.0-beta1` build
+
 0.6.11 (10-24-24)
 ---
 - Update `aoa-tools/render-manifests.sh`. Non-manifest details (environment details, kustomization file locations, etc.) are now prefixed with # to make the output directly usable with kubectl apply.

--- a/environments/gloo-gateway/gateway-api/1.18/ai-gateway/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/ai-gateway/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -94,8 +94,8 @@ spec:
               requestTimeout: 5s
               deployment:
                 logLevel: debug
-    repoURL: https://storage.googleapis.com/gloo-ee-test-helm
-    targetRevision: 1.18.0-beta2-bmain-1203aed
+    repoURL: http://storage.googleapis.com/gloo-ee-helm
+    targetRevision: 1.18.0-beta1
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).


### PR DESCRIPTION
0.6.12 (10-30-24)
---
- reset 1.18/ai-gateway env to use helm chart from `http://storage.googleapis.com/gloo-ee-helm` and `1.18.0-beta1` build