### PR TITLE
see CHANGELOG (0.7.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+0.7.10 (1-14-25)
+---
+- update kiali configmap to include ilm-v3 "gloo" revision label in `gateway-api/1.18/with-ilm-ambient` environment. This gets rid of warnings in the kiali UI
+
 0.7.9 (1-13-25)
 ---
 - update gloo-operator to 0.1.0-beta.2 in gateway-api/1.18/with-ilm-ambient environment

--- a/environments/gloo-gateway/gateway-api/1.18/with-ilm-ambient/istio/ambient/kiali.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-ilm-ambient/istio/ambient/kiali.yaml
@@ -106,6 +106,7 @@ data:
         enabled: true
       istio:
         root_namespace: istio-system
+        # added when using ilm-v3 since it uses the "gloo" revision label
         config_map_name: "istio-gloo"
         istio_sidecar_injector_config_map_name: "istio-sidecar-injector-gloo"
         istiod_deployment_name: "istiod-gloo"

--- a/environments/gloo-gateway/gateway-api/1.18/with-ilm-ambient/istio/ambient/kiali.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-ilm-ambient/istio/ambient/kiali.yaml
@@ -106,6 +106,9 @@ data:
         enabled: true
       istio:
         root_namespace: istio-system
+        config_map_name: "istio-gloo"
+        istio_sidecar_injector_config_map_name: "istio-sidecar-injector-gloo"
+        istiod_deployment_name: "istiod-gloo"
       tracing:
         enabled: false
     identity:

--- a/environments/gloo-gateway/gateway-api/1.18/with-ilm-ambient/istio/ambient/kustomization.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-ilm-ambient/istio/ambient/kustomization.yaml
@@ -10,4 +10,3 @@ resources:
 #- jaeger.yaml
 #- grafana.yaml
 - servicemeshcontroller.yaml
-


### PR DESCRIPTION
0.7.10 (1-14-25)
---
- update kiali configmap to include ilm-v3 "gloo" revision label in `gateway-api/1.18/with-ilm-ambient` environment. This gets rid of warnings in the kiali UI