### PR TITLE
see CHANGELOG (0.8.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+0.8.4 (1-31-25)
+---
+- update /gloo-gateway environments to use gloo-gateway 1.18.3 / istio 1.24.2 / `main` as revision tag / gloo-platform 2.6.9 (where used)
+- update /gloo-gateway/oss environments to use OSS gloo-gateway 1.18.6
+- update /gloo-mesh-core environments to use gloo-platform 2.6.9 / istio 1.24.2 / `main` as revision tag
+- update /gloo-mesh-gateway environments to use gloo-platform 2.6.9 / istio 1.24.2 / `main` as revision tag
+- update /gloo-platform environments to use gloo-platform 2.6.9 / istio 1.24.2 / `main` as revision tag
+- update /istio environments to use istio 1.24.2 / `main` as revision tag
+
 0.8.3 (1-30-25)
 ---
 - updates/fixes to gateway-api/1.18/with-ilm-ambient/multicluster environments

--- a/aoa-tools/tools/colima-install.sh
+++ b/aoa-tools/tools/colima-install.sh
@@ -10,6 +10,7 @@ fi
 # new
 colima start --cpu 6 --memory 16 \
   --profile=${cluster_context} \
+  --network-address \
   --vm-type=vz \
   --kubernetes \
   --kubernetes-version v1.31.2+k3s1 \

--- a/environments/gloo-gateway/gateway-api/1.18/ai-gateway/chatbots/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/ai-gateway/chatbots/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -95,7 +95,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.0-rc3
+    targetRevision: 1.18.0-rc1
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/argo-rollouts/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/argo-rollouts/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -95,7 +95,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.1
+    targetRevision: 1.18.3
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/oss/gloo-oss-app/base/gloo-oss.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/oss/gloo-oss-app/base/gloo-oss.yaml
@@ -41,7 +41,7 @@ spec:
           # We don't need the discovery deployment for our Gloo Gateway demo
           enabled: false
     repoURL: https://storage.googleapis.com/solo-public-helm
-    targetRevision: 1.18.1
+    targetRevision: 1.18.3
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/oss/gloo-oss-app/base/gloo-oss.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/oss/gloo-oss-app/base/gloo-oss.yaml
@@ -41,7 +41,7 @@ spec:
           # We don't need the discovery deployment for our Gloo Gateway demo
           enabled: false
     repoURL: https://storage.googleapis.com/solo-public-helm
-    targetRevision: 1.18.3
+    targetRevision: 1.18.6
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/portal-only/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/portal-only/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -98,7 +98,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.1
+    targetRevision: 1.18.3
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/standalone/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/standalone/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -95,7 +95,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.1
+    targetRevision: 1.18.3
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/bookinfo-app/base/bookinfo-ns.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/bookinfo-app/base/bookinfo-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bookinfo
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/client-app/base/in-mesh-client.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/client-app/base/in-mesh-client.yaml
@@ -34,7 +34,7 @@ spec:
     metadata:
       labels:
         name: in-mesh-client
-        istio.io/rev: 1-24
+        istio.io/rev: main
     spec:
       serviceAccountName: in-mesh-client
       containers:

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/clusterconfig/base/gloo-mesh-addons-ns.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/clusterconfig/base/gloo-mesh-addons-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: gloo-mesh-addons
   #labels:
-  #  istio.io/rev: 1-24
+  #  istio.io/rev: main

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -25,7 +25,7 @@ spec:
               glooGateway:
                 istio:
                   istioProxyContainer:
-                    istioDiscoveryAddress: istiod-1-24.istio-system.svc:15012
+                    istioDiscoveryAddress: istiod-main.istio-system.svc:15012
                     istioMetaClusterId: Kubernetes
                     istioMetaMeshId: Kubernetes
           gatewayProxies:
@@ -107,7 +107,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.1
+    targetRevision: 1.18.3
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
     helm:
       values: |
         featureGates:

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-platform/base/gloo-platform-helm.yaml
@@ -66,7 +66,7 @@ spec:
             #                annotations:
             #                    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             #                labels:
-            #                    istio.io/rev: 1-24
+            #                    istio.io/rev: main
             #                    sidecar.istio.io/inject: "true"
             enabled: true
             serviceType: ClusterIP
@@ -97,13 +97,13 @@ spec:
             #image:
             #  pullPolicy: IfNotPresent
             #  repository: gcr.io/gloo-mesh/gloo-otel-collector
-            #  tag: 2.6.6
+            #  tag: 2.6.9
         telemetryCollector:
             enabled: true
             #image:
             #  pullPolicy: IfNotPresent
             #  repository: gcr.io/gloo-mesh/gloo-otel-collector
-            #  tag: 2.6.6
+            #  tag: 2.6.9
             config:
                 exporters:
                     otlp:
@@ -194,7 +194,7 @@ spec:
                                     - __meta_kubernetes_pod_phase
 
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-platform/base/mgmt-grafana.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-platform/base/mgmt-grafana.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/httpbin-app/base/httpbin-ns.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/httpbin-app/base/httpbin-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: httpbin
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/istio/base/istio-base.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/istio/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/istio/base/istiod.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/istio/base/istiod.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           accessLogFile: /dev/stdout
           enableAutoMtls: true
@@ -40,6 +40,6 @@ spec:
   ignoreDifferences:
     - group: admissionregistration.k8s.io
       kind: ValidatingWebhookConfiguration
-      name: istio-validator-1-24-istio-system
+      name: istio-validator-main-istio-system
       jsonPointers:
         - /webhooks/0/failurePolicy

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/istio/base/kiali.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/istio/base/kiali.yaml
@@ -74,7 +74,7 @@ data:
       pod_annotations: {}
       pod_labels:
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-24
+        istio.io/rev: main
       priority_class_name: ""
       replicas: 1
       resources:
@@ -116,9 +116,9 @@ data:
         url: http://prometheus:9090/prometheus
       ### add the following if using revisioned based istio installation
       istio:
-        config_map_name: istio-1-24
-        istio_sidecar_injector_config_map_name: istio-sidecar-injector-1-24
-        istiod_deployment_name: istiod-1-24
+        config_map_name: istio-main
+        istio_sidecar_injector_config_map_name: istio-sidecar-injector-main
+        istiod_deployment_name: istiod-main
         root_namespace: istio-system
     identity:
       cert_file: ""

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/istio/test.sh
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/istio/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istiod-1-24 istio-system 10 ${cluster_context}
-#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-24 istio-eastwest 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istiod-main istio-system 10 ${cluster_context}
+#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-main istio-eastwest 10 ${cluster_context}

--- a/environments/gloo-gateway/gateway-api/1.18/with-ilm-ambient/base/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-ilm-ambient/base/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -95,7 +95,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.1
+    targetRevision: 1.18.3
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -95,7 +95,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.1
+    targetRevision: 1.18.3
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-base.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.4
+    targetRevision: 1.24.2
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-cni.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-cni.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: cni
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.4
+    targetRevision: 1.24.2
     helm:
       values: |
         profile: ambient

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-ingressgateway.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.4
+    targetRevision: 1.24.2
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-ztunnel.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-ztunnel.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: ztunnel
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.4
+    targetRevision: 1.24.2
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istiod.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.4
+    targetRevision: 1.24.2
     helm:
       values: |
         profile: ambient

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/gke/istio-cni.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/gke/istio-cni.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: cni
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.4
+    targetRevision: 1.24.2
     helm:
       values: |
         profile: ambient

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/bookinfo-app/base/bookinfo-ns.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/bookinfo-app/base/bookinfo-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bookinfo
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/client-app/base/in-mesh-client.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/client-app/base/in-mesh-client.yaml
@@ -34,7 +34,7 @@ spec:
     metadata:
       labels:
         name: in-mesh-client
-        istio.io/rev: 1-24
+        istio.io/rev: main
     spec:
       serviceAccountName: in-mesh-client
       containers:

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -25,7 +25,7 @@ spec:
               glooGateway:
                 istio:
                   istioProxyContainer:
-                    istioDiscoveryAddress: istiod-1-24.istio-system.svc:15012
+                    istioDiscoveryAddress: istiod-main.istio-system.svc:15012
                     istioMetaClusterId: Kubernetes
                     istioMetaMeshId: Kubernetes
           gatewayProxies:
@@ -107,7 +107,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.1
+    targetRevision: 1.18.3
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/httpbin-app/base/httpbin-ns.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/httpbin-app/base/httpbin-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: httpbin
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/istio/base/istio-base.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/istio/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/istio/base/istiod.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/istio/base/istiod.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           accessLogFile: /dev/stdout
           enableAutoMtls: true
@@ -40,6 +40,6 @@ spec:
   ignoreDifferences:
     - group: admissionregistration.k8s.io
       kind: ValidatingWebhookConfiguration
-      name: istio-validator-1-24-istio-system
+      name: istio-validator-main-istio-system
       jsonPointers:
         - /webhooks/0/failurePolicy

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/istio/base/kiali.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/istio/base/kiali.yaml
@@ -74,7 +74,7 @@ data:
       pod_annotations: {}
       pod_labels:
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-24
+        istio.io/rev: main
       priority_class_name: ""
       replicas: 1
       resources:
@@ -116,9 +116,9 @@ data:
         url: http://prometheus:9090/prometheus
       ### add the following if using revisioned based istio installation
       istio:
-        config_map_name: istio-1-24
-        istio_sidecar_injector_config_map_name: istio-sidecar-injector-1-24
-        istiod_deployment_name: istiod-1-24
+        config_map_name: istio-main
+        istio_sidecar_injector_config_map_name: istio-sidecar-injector-main
+        istiod_deployment_name: istiod-main
         root_namespace: istio-system
     identity:
       cert_file: ""

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/istio/test.sh
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/istio/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istiod-1-24 istio-system 10 ${cluster_context}
-#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-24 istio-eastwest 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istiod-main istio-system 10 ${cluster_context}
+#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-main istio-eastwest 10 ${cluster_context}

--- a/environments/gloo-mesh-core/additional-cluster-1/README.md
+++ b/environments/gloo-mesh-core/additional-cluster-1/README.md
@@ -9,6 +9,6 @@ The `gloo-mesh-core/additional-cluster-1` environment bootstraps an additional w
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.24.0-solo (Helm)
-    - revision: 1-24
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main

--- a/environments/gloo-mesh-core/additional-cluster-1/gloo-agent/base/gloo-platform-crds.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/gloo-agent/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/additional-cluster-1/gloo-agent/init.sh
+++ b/environments/gloo-mesh-core/additional-cluster-1/gloo-agent/init.sh
@@ -7,7 +7,7 @@ echo "deploy and register gloo-mesh agent and addons"
 if [[ ${gloo_mesh_version} == "" ]]
   then
     # provide gloo_mesh_version variable
-    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.6):"
+    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.9):"
     read gloo_mesh_version
 fi
 
@@ -116,7 +116,7 @@ spec:
             runAsSidecar: true  
                 
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true
@@ -172,7 +172,7 @@ spec:
                   name: cilium-run
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/additional-cluster-1/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---

--- a/environments/gloo-mesh-core/additional-cluster-1/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-24
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-core/additional-cluster-1/homer-app/lb-discovery/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/homer-app/lb-discovery/homer-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-mesh-core/additional-cluster-1/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-mesh-core/additional-cluster-1/homer-app/lb-discovery/init.sh
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/grafana.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/grafana.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-ingressgateway.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
-        name: "istio-ingressgateway-1-24"
+        name: "istio-ingressgateway-main"
         # revision declares which revision this gateway is a part of
-        revision: "1-24"
+        revision: "main"
         
         replicaCount: 1
         

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: additional-cluster-1
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           trustDomain: additional-cluster-1
           accessLogFile: /dev/stdout

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/test.sh
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-24 istio-gateways 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-main istio-gateways 10 ${cluster_context}

--- a/environments/gloo-mesh-core/additional-cluster-1/online-boutique-app/base/backend-apis-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/online-boutique-app/base/backend-apis-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: backend-apis
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-mesh-core/additional-cluster-1/online-boutique-app/base/web-ui-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/online-boutique-app/base/web-ui-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: web-ui
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-mesh-core/additional-cluster-1/vars.env
+++ b/environments/gloo-mesh-core/additional-cluster-1/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="additional-cluster-1"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-mesh-core/additional-cluster-2/README.md
+++ b/environments/gloo-mesh-core/additional-cluster-2/README.md
@@ -9,6 +9,6 @@ The `gloo-mesh-core/additional-cluster-2` environment bootstraps an additional w
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.24.0-solo (Helm)
-    - revision: 1-24
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main

--- a/environments/gloo-mesh-core/additional-cluster-2/bookinfo-app/base/bookinfo-backends-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/bookinfo-app/base/bookinfo-backends-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bookinfo-backends
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-mesh-core/additional-cluster-2/bookinfo-app/base/bookinfo-frontends-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/bookinfo-app/base/bookinfo-frontends-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bookinfo-frontends
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-mesh-core/additional-cluster-2/gloo-agent/base/gloo-platform-crds.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/gloo-agent/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/additional-cluster-2/gloo-agent/init.sh
+++ b/environments/gloo-mesh-core/additional-cluster-2/gloo-agent/init.sh
@@ -7,7 +7,7 @@ echo "deploy and register gloo-mesh agent and addons"
 if [[ ${gloo_mesh_version} == "" ]]
   then
     # provide gloo_mesh_version variable
-    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.6):"
+    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.9):"
     read gloo_mesh_version
 fi
 
@@ -116,7 +116,7 @@ spec:
             runAsSidecar: true  
                 
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true
@@ -172,7 +172,7 @@ spec:
                   name: cilium-run
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/additional-cluster-2/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---

--- a/environments/gloo-mesh-core/additional-cluster-2/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-24
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-core/additional-cluster-2/homer-app/lb-discovery/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/homer-app/lb-discovery/homer-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-mesh-core/additional-cluster-2/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-mesh-core/additional-cluster-2/homer-app/lb-discovery/init.sh
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/grafana.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/grafana.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-ingressgateway.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
-        name: "istio-ingressgateway-1-24"
+        name: "istio-ingressgateway-main"
         # revision declares which revision this gateway is a part of
-        revision: "1-24"
+        revision: "main"
         
         replicaCount: 1
         

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: additional-cluster-2
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           trustDomain: additional-cluster-2
           accessLogFile: /dev/stdout

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/test.sh
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-24 istio-gateways 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-main istio-gateways 10 ${cluster_context}

--- a/environments/gloo-mesh-core/additional-cluster-2/vars.env
+++ b/environments/gloo-mesh-core/additional-cluster-2/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="additional-cluster-2"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-mesh-core/singlecluster/README.md
+++ b/environments/gloo-mesh-core/singlecluster/README.md
@@ -8,6 +8,6 @@ The `gloo-mesh-core/singlecluster` environment deploys the core components of a 
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.24.0-solo (Helm)
-    - revision: 1-24
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main

--- a/environments/gloo-mesh-core/singlecluster/gloo-mesh-core/base/gloo-platform-crds.yaml
+++ b/environments/gloo-mesh-core/singlecluster/gloo-mesh-core/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/singlecluster/gloo-mesh-core/base/gloo-platform-helm.yaml
+++ b/environments/gloo-mesh-core/singlecluster/gloo-mesh-core/base/gloo-platform-helm.yaml
@@ -98,7 +98,7 @@ spec:
                   name: cilium-run
 
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/singlecluster/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-core/singlecluster/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---

--- a/environments/gloo-mesh-core/singlecluster/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-mesh-core/singlecluster/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-24
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-core/singlecluster/homer-app/lb-discovery/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-core/singlecluster/homer-app/lb-discovery/homer-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-mesh-core/singlecluster/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-mesh-core/singlecluster/homer-app/lb-discovery/init.sh
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/grafana.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/grafana.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-ingressgateway.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
-        name: "istio-ingressgateway-1-24"
+        name: "istio-ingressgateway-main"
         # revision declares which revision this gateway is a part of
-        revision: "1-24"
+        revision: "main"
         
         replicaCount: 1
         

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: mgmt
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           trustDomain: mgmt
           accessLogFile: /dev/stdout

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/test.sh
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-24 istio-gateways 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-main istio-gateways 10 ${cluster_context}

--- a/environments/gloo-mesh-core/singlecluster/online-boutique-app/base/backend-apis-ns.yaml
+++ b/environments/gloo-mesh-core/singlecluster/online-boutique-app/base/backend-apis-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: backend-apis
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-mesh-core/singlecluster/online-boutique-app/base/web-ui-ns.yaml
+++ b/environments/gloo-mesh-core/singlecluster/online-boutique-app/base/web-ui-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: web-ui
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-mesh-gateway/bookinfo/README.md
+++ b/environments/gloo-mesh-gateway/bookinfo/README.md
@@ -10,6 +10,6 @@ The `gloo-gateway/backstage-bookinfo-httpbin` environment deploys the core compo
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.23.0-solo (Helm)
-    - revision: 1-23
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main

--- a/environments/gloo-mesh-gateway/bookinfo/bookinfo-app/base/bookinfo-backends-ns.yaml
+++ b/environments/gloo-mesh-gateway/bookinfo/bookinfo-app/base/bookinfo-backends-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bookinfo-backends
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main

--- a/environments/gloo-mesh-gateway/bookinfo/bookinfo-app/base/bookinfo-frontends-ns.yaml
+++ b/environments/gloo-mesh-gateway/bookinfo/bookinfo-app/base/bookinfo-frontends-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bookinfo-frontends
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main

--- a/environments/gloo-mesh-gateway/bookinfo/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-gateway/bookinfo/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---

--- a/environments/gloo-mesh-gateway/bookinfo/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-mesh-gateway/bookinfo/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-23
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-gateway/bookinfo/homer-app/localhost/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-gateway/bookinfo/homer-app/localhost/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---

--- a/environments/gloo-mesh-gateway/bookinfo/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-mesh-gateway/bookinfo/homer-app/localhost/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-23
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-gateway/bookinfo/ilm/README.md
+++ b/environments/gloo-mesh-gateway/bookinfo/ilm/README.md
@@ -29,9 +29,9 @@ The `gloo-gateway/backstage-bookinfo-httpbin` environment deploys the core compo
 
 ## Overlay description
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.23.0-solo (Helm)
-    - revision: 1-23
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main
 
 ## Application description
 
@@ -54,7 +54,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-23
+ISTIO_REVISION=main
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.items[*].status.loadBalancer.ingress[0].ip}{.items[*].status.loadBalancer.ingress[0].hostname}')
 
 echo ${GATEWAY_IP}
@@ -95,7 +95,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-23
+ISTIO_REVISION=main
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-mesh-gateway/core/README.md
+++ b/environments/gloo-mesh-gateway/core/README.md
@@ -10,6 +10,6 @@ The `gloo-gateway/core` environment deploys the core components of a single clus
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.23.0-solo (Helm)
-    - revision: 1-23
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main

--- a/environments/gloo-mesh-gateway/core/clusterconfig/base/gloo-mesh-addons-ns.yaml
+++ b/environments/gloo-mesh-gateway/core/clusterconfig/base/gloo-mesh-addons-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: gloo-mesh-addons
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main

--- a/environments/gloo-mesh-gateway/core/clusterconfig/base/httpbin-ns.yaml
+++ b/environments/gloo-mesh-gateway/core/clusterconfig/base/httpbin-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: httpbin
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main

--- a/environments/gloo-mesh-gateway/core/clusterconfig/base/istio-eastwest-ns.yaml
+++ b/environments/gloo-mesh-gateway/core/clusterconfig/base/istio-eastwest-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: istio-eastwest
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main

--- a/environments/gloo-mesh-gateway/core/clusterconfig/base/istio-gateways-ns.yaml
+++ b/environments/gloo-mesh-gateway/core/clusterconfig/base/istio-gateways-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: istio-gateways
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main

--- a/environments/gloo-mesh-gateway/core/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-mesh-gateway/core/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-gateway/core/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-mesh-gateway/core/gloo-platform/base/gloo-platform-helm.yaml
@@ -63,7 +63,7 @@ spec:
             #                annotations:
             #                    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             #                labels:
-            #                    istio.io/rev: 1-23
+            #                    istio.io/rev: main
             #                    sidecar.istio.io/inject: "true"
             enabled: true
             serviceType: ClusterIP
@@ -94,13 +94,13 @@ spec:
             #image:
             #  pullPolicy: IfNotPresent
             #  repository: gcr.io/gloo-mesh/gloo-otel-collector
-            #  tag: 2.6.6
+            #  tag: 2.6.9
         telemetryCollector:
             enabled: true
             #image:
             #  pullPolicy: IfNotPresent
             #  repository: gcr.io/gloo-mesh/gloo-otel-collector
-            #  tag: 2.6.6
+            #  tag: 2.6.9
             config:
                 exporters:
                     otlp:
@@ -191,7 +191,7 @@ spec:
                                     - __meta_kubernetes_pod_phase
 
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-gateway/core/gloo-platform/base/mgmt-grafana.yaml
+++ b/environments/gloo-mesh-gateway/core/gloo-platform/base/mgmt-grafana.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-mesh-gateway/core/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-gateway/core/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---

--- a/environments/gloo-mesh-gateway/core/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-mesh-gateway/core/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-23
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-gateway/core/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-gateway/core/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---

--- a/environments/gloo-mesh-gateway/core/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-mesh-gateway/core/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-23
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-gateway/core/homer-app/lb-discovery/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-gateway/core/homer-app/lb-discovery/homer-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main

--- a/environments/gloo-mesh-gateway/core/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-mesh-gateway/core/homer-app/lb-discovery/init.sh
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/environments/gloo-mesh-gateway/core/istio/helm/base/grafana.yaml
+++ b/environments/gloo-mesh-gateway/core/istio/helm/base/grafana.yaml
@@ -126,7 +126,7 @@ spec:
         app.kubernetes.io/instance: grafana
         app: grafana
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-23
+        istio.io/rev: main
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
         checksum/config: 0db0166dec9b75eb6486494512ab843bc085e0806457bc09e92597a418a115ae

--- a/environments/gloo-mesh-gateway/core/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-mesh-gateway/core/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.0
+    targetRevision: 1.24.2
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-gateway/core/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-gateway/core/istio/helm/base/istio-ingressgateway.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.0
+    targetRevision: 1.24.2
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
-        name: "istio-ingressgateway-1-23"
+        name: "istio-ingressgateway-main"
         # revision declares which revision this gateway is a part of
-        revision: "1-23"
+        revision: "main"
         
         replicaCount: 1
         

--- a/environments/gloo-mesh-gateway/core/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-gateway/core/istio/helm/base/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-23
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: mgmt
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.23.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           trustDomain: mgmt
           accessLogFile: /dev/stdout

--- a/environments/gloo-mesh-gateway/core/istio/helm/test.sh
+++ b/environments/gloo-mesh-gateway/core/istio/helm/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-23 istio-gateways 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-main istio-gateways 10 ${cluster_context}

--- a/environments/gloo-mesh-gateway/httpbin/README.md
+++ b/environments/gloo-mesh-gateway/httpbin/README.md
@@ -10,6 +10,6 @@ The `gloo-gateway/httpbin` environment deploys the core components of a single c
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.23.0-solo (Helm)
-    - revision: 1-23
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main

--- a/environments/gloo-mesh-gateway/httpbin/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-gateway/httpbin/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---

--- a/environments/gloo-mesh-gateway/httpbin/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-mesh-gateway/httpbin/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-23
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-gateway/httpbin/homer-app/localhost/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-gateway/httpbin/homer-app/localhost/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---

--- a/environments/gloo-mesh-gateway/httpbin/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-mesh-gateway/httpbin/homer-app/localhost/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-23
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-gateway/httpbin/httpbin-app/base/httpbin-in-mesh.yaml
+++ b/environments/gloo-mesh-gateway/httpbin/httpbin-app/base/httpbin-in-mesh.yaml
@@ -39,7 +39,7 @@ spec:
       labels:
         app: in-mesh
         version: v1
-        istio.io/rev: 1-23
+        istio.io/rev: main
     spec:
       serviceAccountName: in-mesh
       containers:
@@ -68,7 +68,7 @@ spec:
       labels:
         app: in-mesh
         version: v2
-        istio.io/rev: 1-23
+        istio.io/rev: main
     spec:
       serviceAccountName: in-mesh
       containers:

--- a/environments/gloo-mesh-gateway/onlineboutique/README.md
+++ b/environments/gloo-mesh-gateway/onlineboutique/README.md
@@ -10,6 +10,6 @@ The `gloo-gateway/onlineboutique` environment deploys the core components of a s
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.23.0-solo (Helm)
-    - revision: 1-23
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main

--- a/environments/gloo-mesh-gateway/onlineboutique/glootest.com/README.md
+++ b/environments/gloo-mesh-gateway/onlineboutique/glootest.com/README.md
@@ -23,9 +23,9 @@ The `gloo-gateway/onlineboutique` environment deploys the core components of a s
 
 ## Overlay description
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.23.0-solo (Helm)
-    - revision: 1-23
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main
 
 ## Application description
 
@@ -45,7 +45,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-23
+ISTIO_REVISION=main
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.items[*].status.loadBalancer.ingress[0].ip}{.items[*].status.loadBalancer.ingress[0].hostname}')
 
 echo ${GATEWAY_IP}
@@ -86,7 +86,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-23
+ISTIO_REVISION=main
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-mesh-gateway/onlineboutique/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-gateway/onlineboutique/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---

--- a/environments/gloo-mesh-gateway/onlineboutique/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-mesh-gateway/onlineboutique/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-23
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-gateway/onlineboutique/homer-app/lb-discovery/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-gateway/onlineboutique/homer-app/lb-discovery/homer-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main

--- a/environments/gloo-mesh-gateway/onlineboutique/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-mesh-gateway/onlineboutique/homer-app/lb-discovery/init.sh
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/environments/gloo-mesh-gateway/onlineboutique/homer-app/localhost/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-gateway/onlineboutique/homer-app/localhost/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---

--- a/environments/gloo-mesh-gateway/onlineboutique/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-mesh-gateway/onlineboutique/homer-app/localhost/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-23
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-gateway/onlineboutique/homer-app/tracing/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-gateway/onlineboutique/homer-app/tracing/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---

--- a/environments/gloo-mesh-gateway/onlineboutique/homer-app/tracing/homer-portal.yaml
+++ b/environments/gloo-mesh-gateway/onlineboutique/homer-app/tracing/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-23
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-gateway/onlineboutique/online-boutique-app/base/backend-apis-ns.yaml
+++ b/environments/gloo-mesh-gateway/onlineboutique/online-boutique-app/base/backend-apis-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: backend-apis
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main

--- a/environments/gloo-mesh-gateway/onlineboutique/online-boutique-app/base/web-ui-ns.yaml
+++ b/environments/gloo-mesh-gateway/onlineboutique/online-boutique-app/base/web-ui-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: web-ui
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main

--- a/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/README.md
+++ b/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/README.md
@@ -10,6 +10,6 @@ The `gloo-gateway/progressive-delivery-argo-rollouts` environment deploys the co
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.23.0-solo (Helm)
-    - revision: 1-23
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main

--- a/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/glootest.com/README.md
+++ b/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/glootest.com/README.md
@@ -23,9 +23,9 @@ The `gloo-gateway/onlineboutique` environment deploys the core components of a s
 
 ## Overlay description
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.23.0-solo (Helm)
-    - revision: 1-23
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main
 
 ## Application description
 
@@ -45,7 +45,7 @@ To access applications, follow the methods below:
 
 Discover your gateway IP address
 ```
-ISTIO_REVISION=1-23
+ISTIO_REVISION=main
 GATEWAY_IP=$(kubectl -n istio-gateways get service istio-ingressgateway-${ISTIO_REVISION} -o jsonpath='{.items[*].status.loadBalancer.ingress[0].ip}{.items[*].status.loadBalancer.ingress[0].hostname}')
 
 echo ${GATEWAY_IP}
@@ -86,7 +86,7 @@ access gloo mesh ui at https://localhost:8090"
 
 To access Istio Ingress Gateway using port-forward command:
 ```
-ISTIO_REVISION=1-23
+ISTIO_REVISION=main
 kubectl port-forward -n istio-gateways svc/istio-ingressgateway-${ISTIO_REVISION} 8443:443 --context <cluster_name>
 ```
 access the ingress gateway at https://localhost:8443

--- a/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/helloworld-rollout/base/helloworld-ns.yaml
+++ b/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/helloworld-rollout/base/helloworld-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: helloworld
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main

--- a/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---

--- a/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-23
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/homer-app/lb-discovery/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/homer-app/lb-discovery/homer-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main

--- a/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/homer-app/lb-discovery/init.sh
+++ b/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/homer-app/lb-discovery/init.sh
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/homer-app/localhost/homer-portal-ns.yaml
+++ b/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/homer-app/localhost/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---

--- a/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/homer-app/localhost/homer-portal.yaml
+++ b/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/homer-app/localhost/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-23
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/rollouts-demo/base/rollouts-demo-ns.yaml
+++ b/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/rollouts-demo/base/rollouts-demo-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: rollouts-demo
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main

--- a/environments/gloo-platform/core/cluster1/README.md
+++ b/environments/gloo-platform/core/cluster1/README.md
@@ -10,6 +10,6 @@ The `gloo-platform/core/cluster1` environment deploys the `cluster1` worker for 
 
 ## Environment description
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.24.0-solo (Helm)
-    - revision: 1-24
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main

--- a/environments/gloo-platform/core/cluster1/clusterconfig/base/bookinfo-backends-ns.yaml
+++ b/environments/gloo-platform/core/cluster1/clusterconfig/base/bookinfo-backends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
   name: bookinfo-backends

--- a/environments/gloo-platform/core/cluster1/clusterconfig/base/bookinfo-frontends-ns.yaml
+++ b/environments/gloo-platform/core/cluster1/clusterconfig/base/bookinfo-frontends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
   name: bookinfo-frontends

--- a/environments/gloo-platform/core/cluster1/gloo-platform/base/gloo-platform-addons.yaml
+++ b/environments/gloo-platform/core/cluster1/gloo-platform/base/gloo-platform-addons.yaml
@@ -23,7 +23,7 @@ spec:
         rateLimiter:
             enabled: true
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/cluster1/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-platform/core/cluster1/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/cluster1/gloo-platform/init.sh
+++ b/environments/gloo-platform/core/cluster1/gloo-platform/init.sh
@@ -7,7 +7,7 @@ echo "deploy and register gloo-mesh agent and addons"
 if [[ ${gloo_mesh_version} == "" ]]
   then
     # provide gloo_mesh_version variable
-    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.6):"
+    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.9):"
     read gloo_mesh_version
 fi
 
@@ -78,7 +78,7 @@ spec:
             runAsSidecar: true  
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true
@@ -120,13 +120,13 @@ spec:
             #service: 
             #  type: ClusterIP
             #podLabels:
-            #  istio.io/rev: 1-24
+            #  istio.io/rev: main
             #podAnnotations:
             #  proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.6
+              tag: 2.6.9
             config:
                 exporters:
                     otlp:
@@ -148,7 +148,7 @@ spec:
                   name: cilium-run
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/cluster1/istio/helm/base/grafana-helm.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/base/grafana-helm.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-platform/core/cluster1/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/base/istio-eastwestgateway.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
         name: "istio-eastwestgateway"
         # revision declares which revision this gateway is a part of
-        revision: "1-24"
+        revision: "main"
         
         replicaCount: 1
         
@@ -55,7 +55,7 @@ spec:
         
         # Labels to apply to all resources
         labels:
-          istio.io/rev: 1-24
+          istio.io/rev: main
           istio: eastwestgateway
           topology.istio.io/network: cluster1
   syncPolicy:

--- a/environments/gloo-platform/core/cluster1/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/base/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: cluster1
           network: cluster1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           trustDomain: cluster1
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/core/cluster1/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/tracing/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: cluster1
           network: cluster1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/core/cluster1/vars.env
+++ b/environments/gloo-platform/core/cluster1/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="cluster1"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/core/cluster2/README.md
+++ b/environments/gloo-platform/core/cluster2/README.md
@@ -10,6 +10,6 @@ The `gloo-platform/core/cluster2` environment deploys the `cluster2` worker for 
 
 ## Environment description
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.24.0-solo (Helm)
-    - revision: 1-24
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main

--- a/environments/gloo-platform/core/cluster2/clusterconfig/base/bookinfo-backends-ns.yaml
+++ b/environments/gloo-platform/core/cluster2/clusterconfig/base/bookinfo-backends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
   name: bookinfo-backends

--- a/environments/gloo-platform/core/cluster2/clusterconfig/base/bookinfo-frontends-ns.yaml
+++ b/environments/gloo-platform/core/cluster2/clusterconfig/base/bookinfo-frontends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
   name: bookinfo-frontends

--- a/environments/gloo-platform/core/cluster2/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-platform/core/cluster2/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/cluster2/gloo-platform/init.sh
+++ b/environments/gloo-platform/core/cluster2/gloo-platform/init.sh
@@ -7,7 +7,7 @@ echo "deploy and register gloo-mesh agent and addons"
 if [[ ${gloo_mesh_version} == "" ]]
   then
     # provide gloo_mesh_version variable
-    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.6):"
+    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.9):"
     read gloo_mesh_version
 fi
 
@@ -78,7 +78,7 @@ spec:
             runAsSidecar: true  
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true
@@ -120,13 +120,13 @@ spec:
             #service: 
             #  type: ClusterIP
             #podLabels:
-            #  istio.io/rev: 1-24
+            #  istio.io/rev: main
             #podAnnotations:
             #  proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.6
+              tag: 2.6.9
             config:
                 exporters:
                     otlp:
@@ -148,7 +148,7 @@ spec:
                   name: cilium-run
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/cluster2/istio/helm/base/grafana-helm.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/helm/base/grafana-helm.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-platform/core/cluster2/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/helm/base/istio-eastwestgateway.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
         name: "istio-eastwestgateway"
         # revision declares which revision this gateway is a part of
-        revision: "1-24"
+        revision: "main"
         
         replicaCount: 1
         
@@ -55,7 +55,7 @@ spec:
         
         # Labels to apply to all resources
         labels:
-          istio.io/rev: 1-24
+          istio.io/rev: main
           istio: eastwestgateway
           topology.istio.io/network: cluster2
   syncPolicy:

--- a/environments/gloo-platform/core/cluster2/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/helm/base/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: cluster2
           network: cluster2
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           trustDomain: cluster2
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/core/cluster2/vars.env
+++ b/environments/gloo-platform/core/cluster2/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="cluster2"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/core/mgmt/README.md
+++ b/environments/gloo-platform/core/mgmt/README.md
@@ -18,6 +18,6 @@ When applied with `cluster1` and `cluster2` environments, here is a high level d
 
 ## Environment description
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.24.0-solo (Helm)
-    - revision: 1-24
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main

--- a/environments/gloo-platform/core/mgmt/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-platform/core/mgmt/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/mgmt/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-platform/core/mgmt/gloo-platform/base/gloo-platform-helm.yaml
@@ -63,7 +63,7 @@ spec:
             #                annotations:
             #                    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             #                labels:
-            #                    istio.io/rev: 1-24
+            #                    istio.io/rev: main
             #                    sidecar.istio.io/inject: "true"
             enabled: true
             serviceType: ClusterIP
@@ -85,7 +85,7 @@ spec:
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.6
+              tag: 2.6.9
         telemetryGatewayCustomization:
             disableCertGeneration: true
         telemetryCollector:
@@ -96,13 +96,13 @@ spec:
             #service: 
             #    type: ClusterIP
             #podLabels:
-            #    istio.io/rev: 1-24
+            #    istio.io/rev: main
             #podAnnotations:
             #    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.6
+              tag: 2.6.9
             config:
                 exporters:
                     otlp:
@@ -124,7 +124,7 @@ spec:
                   name: cilium-run
         
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/mgmt/glootest.com/vars.env
+++ b/environments/gloo-platform/core/mgmt/glootest.com/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/core/mgmt/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-platform/core/mgmt/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---

--- a/environments/gloo-platform/core/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/core/mgmt/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-24
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/core/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/core/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-24
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/grafana-helm.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/grafana-helm.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/istio-eastwestgateway.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
         name: "istio-eastwestgateway"
         # revision declares which revision this gateway is a part of
-        revision: "1-24"
+        revision: "main"
         
         replicaCount: 1
         
@@ -55,7 +55,7 @@ spec:
         
         # Labels to apply to all resources
         labels:
-          istio.io/rev: 1-24
+          istio.io/rev: main
           istio: eastwestgateway
           topology.istio.io/network: mgmt
   syncPolicy:

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/istio-ingressgateway.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
-        name: "istio-ingressgateway-1-24"
+        name: "istio-ingressgateway-main"
         # revision declares which revision this gateway is a part of
-        revision: "1-24"
+        revision: "main"
         
         replicaCount: 1
         
@@ -49,7 +49,7 @@ spec:
         
         # Labels to apply to all resources
         labels:
-          istio.io/rev: 1-24
+          istio.io/rev: main
           istio: mgmt-ingressgateway
   syncPolicy:
     automated: {}

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: mgmt
           network: mgmt
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           trustDomain: mgmt
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/core/mgmt/istio/helm/test.sh
+++ b/environments/gloo-platform/core/mgmt/istio/helm/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-24 istio-gateways 10 ${cluster_context}
-#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-24 istio-eastwest 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-main istio-gateways 10 ${cluster_context}
+#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-main istio-eastwest 10 ${cluster_context}

--- a/environments/gloo-platform/core/mgmt/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/tracing/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: mgmt
           network: mgmt
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/core/mgmt/vars.env
+++ b/environments/gloo-platform/core/mgmt/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/core/shared-components/clusterconfig/base/gloo-mesh-addons-ns.yaml
+++ b/environments/gloo-platform/core/shared-components/clusterconfig/base/gloo-mesh-addons-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: gloo-mesh-addons
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-platform/core/shared-components/clusterconfig/base/gloo-mesh-ns.yaml
+++ b/environments/gloo-platform/core/shared-components/clusterconfig/base/gloo-mesh-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: gloo-mesh
   #labels:
-  #  istio.io/rev: 1-24
+  #  istio.io/rev: main

--- a/environments/gloo-platform/core/shared-components/clusterconfig/base/httpbin-ns.yaml
+++ b/environments/gloo-platform/core/shared-components/clusterconfig/base/httpbin-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: httpbin
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-platform/core/shared-components/clusterconfig/base/istio-eastwest-ns.yaml
+++ b/environments/gloo-platform/core/shared-components/clusterconfig/base/istio-eastwest-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: istio-eastwest
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-platform/core/shared-components/clusterconfig/base/istio-gateways-ns.yaml
+++ b/environments/gloo-platform/core/shared-components/clusterconfig/base/istio-gateways-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: istio-gateways
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/grafana.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/grafana.yaml
@@ -126,7 +126,7 @@ spec:
         app.kubernetes.io/instance: grafana
         app: grafana
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-24
+        istio.io/rev: main
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
         checksum/config: 0db0166dec9b75eb6486494512ab843bc085e0806457bc09e92597a418a115ae

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/istio-ingressgateway.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
-        name: "istio-ingressgateway-1-24"
+        name: "istio-ingressgateway-main"
         # revision declares which revision this gateway is a part of
-        revision: "1-24"
+        revision: "main"
         
         replicaCount: 1
         

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: cluster1
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           trustDomain: cluster1
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/core/shared-components/istio/helm/test.sh
+++ b/environments/gloo-platform/core/shared-components/istio/helm/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-24 istio-gateways 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-main istio-gateways 10 ${cluster_context}
 #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}

--- a/environments/gloo-platform/core/shared-components/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/tracing/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: cluster1
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/README.md
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/README.md
@@ -10,6 +10,6 @@ The `gloo-platform/core/cluster1` environment deploys the `cluster1` worker for 
 
 ## Environment description
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.24.0-solo (Helm)
-    - revision: 1-24
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/clusterconfig/base/bookinfo-backends-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/clusterconfig/base/bookinfo-backends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
   name: bookinfo-backends

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/clusterconfig/base/bookinfo-frontends-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/clusterconfig/base/bookinfo-frontends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
   name: bookinfo-frontends

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/gloo-platform/base/gloo-platform-addons.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/gloo-platform/base/gloo-platform-addons.yaml
@@ -23,7 +23,7 @@ spec:
         rateLimiter:
             enabled: true
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/gloo-platform/init.sh
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/gloo-platform/init.sh
@@ -7,7 +7,7 @@ echo "deploy and register gloo-mesh agent and addons"
 if [[ ${gloo_mesh_version} == "" ]]
   then
     # provide gloo_mesh_version variable
-    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.6):"
+    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.9):"
     read gloo_mesh_version
 fi
 
@@ -78,7 +78,7 @@ spec:
             runAsSidecar: true  
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true
@@ -120,13 +120,13 @@ spec:
             #service: 
             #  type: ClusterIP
             #podLabels:
-            #  istio.io/rev: 1-24
+            #  istio.io/rev: main
             #podAnnotations:
             #  proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.6
+              tag: 2.6.9
             config:
                 exporters:
                     otlp:
@@ -148,7 +148,7 @@ spec:
                   name: cilium-run
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/httpbin-app/base/httpbin-in-mesh.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/httpbin-app/base/httpbin-in-mesh.yaml
@@ -40,7 +40,7 @@ spec:
       labels:
         app: in-mesh
         version: v1
-        istio.io/rev: 1-24
+        istio.io/rev: main
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     spec:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/grafana-helm.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/grafana-helm.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istio-eastwestgateway.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
         name: "istio-eastwestgateway"
         # revision declares which revision this gateway is a part of
-        revision: "1-24"
+        revision: "main"
         
         replicaCount: 1
         
@@ -55,7 +55,7 @@ spec:
         
         # Labels to apply to all resources
         labels:
-          istio.io/rev: 1-24
+          istio.io/rev: main
           istio: eastwestgateway
           topology.istio.io/network: cluster1
   syncPolicy:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: cluster1
           network: cluster1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           trustDomain: cluster1
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/tracing/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: cluster1
           network: cluster1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/vars.env
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="cluster1"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/README.md
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/README.md
@@ -10,6 +10,6 @@ The `gloo-platform/core/cluster2` environment deploys the `cluster2` worker for 
 
 ## Environment description
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.24.0-solo (Helm)
-    - revision: 1-24
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/clusterconfig/base/bookinfo-backends-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/clusterconfig/base/bookinfo-backends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
   name: bookinfo-backends

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/clusterconfig/base/bookinfo-frontends-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/clusterconfig/base/bookinfo-frontends-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
   name: bookinfo-frontends

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/gloo-platform/init.sh
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/gloo-platform/init.sh
@@ -7,7 +7,7 @@ echo "deploy and register gloo-mesh agent and addons"
 if [[ ${gloo_mesh_version} == "" ]]
   then
     # provide gloo_mesh_version variable
-    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.6):"
+    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.9):"
     read gloo_mesh_version
 fi
 
@@ -78,7 +78,7 @@ spec:
             runAsSidecar: true  
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true
@@ -120,13 +120,13 @@ spec:
             #service: 
             #  type: ClusterIP
             #podLabels:
-            #  istio.io/rev: 1-24
+            #  istio.io/rev: main
             #podAnnotations:
             #  proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.6
+              tag: 2.6.9
             config:
                 exporters:
                     otlp:
@@ -148,7 +148,7 @@ spec:
                   name: cilium-run
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/httpbin-app/base/httpbin-in-mesh.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/httpbin-app/base/httpbin-in-mesh.yaml
@@ -39,7 +39,7 @@ spec:
       labels:
         app: in-mesh
         version: v3
-        istio.io/rev: 1-24
+        istio.io/rev: main
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     spec:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/grafana-helm.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/grafana-helm.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: grafana
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---
 apiVersion: v1
 kind: Secret

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istio-eastwestgateway.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
         name: "istio-eastwestgateway"
         # revision declares which revision this gateway is a part of
-        revision: "1-24"
+        revision: "main"
         
         replicaCount: 1
         
@@ -55,7 +55,7 @@ spec:
         
         # Labels to apply to all resources
         labels:
-          istio.io/rev: 1-24
+          istio.io/rev: main
           istio: eastwestgateway
           topology.istio.io/network: cluster2
   syncPolicy:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: cluster2
           network: cluster2
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           trustDomain: cluster2
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/tracing/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: cluster2
           network: cluster2
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/vars.env
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="cluster2"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/README.md
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/README.md
@@ -18,6 +18,6 @@ When applied with `cluster1` and `cluster2` environments, here is a high level d
 
 ## Environment description
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.24.0-solo (Helm)
-    - revision: 1-24
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
     helm:
       values: |
         featureGates:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform/base/gloo-platform-helm.yaml
@@ -65,7 +65,7 @@ spec:
             #                annotations:
             #                    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             #                labels:
-            #                    istio.io/rev: 1-24
+            #                    istio.io/rev: main
             #                    sidecar.istio.io/inject: "true"
             enabled: true
             serviceType: ClusterIP
@@ -87,7 +87,7 @@ spec:
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.6
+              tag: 2.6.9
         telemetryGatewayCustomization:
             disableCertGeneration: true
         telemetryCollector:
@@ -98,13 +98,13 @@ spec:
             #service: 
             #    type: ClusterIP
             #podLabels:
-            #    istio.io/rev: 1-24
+            #    istio.io/rev: main
             #podAnnotations:
             #    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.6
+              tag: 2.6.9
             config:
                 exporters:
                     otlp:
@@ -126,7 +126,7 @@ spec:
                   name: cilium-run
         
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.6
+    targetRevision: 2.6.9
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/glootest.com/vars.env
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/glootest.com/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-24
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-24
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/vars.env
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/gloo-mesh-addons-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/gloo-mesh-addons-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: gloo-mesh-addons
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/gloo-mesh-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/gloo-mesh-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: gloo-mesh
   #labels:
-  #  istio.io/rev: 1-24
+  #  istio.io/rev: main

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/httpbin-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/httpbin-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: httpbin
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/istio-eastwest-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/istio-eastwest-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: istio-eastwest
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/istio-gateways-ns.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/clusterconfig/base/istio-gateways-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: istio-gateways
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/grafana.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/grafana.yaml
@@ -126,7 +126,7 @@ spec:
         app.kubernetes.io/instance: grafana
         app: grafana
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-24
+        istio.io/rev: main
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
         checksum/config: 0db0166dec9b75eb6486494512ab843bc085e0806457bc09e92597a418a115ae

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istio-ingressgateway.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
-        name: "istio-ingressgateway-1-24"
+        name: "istio-ingressgateway-main"
         # revision declares which revision this gateway is a part of
-        revision: "1-24"
+        revision: "main"
         
         replicaCount: 1
         

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: cluster1
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           trustDomain: cluster1
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/test.sh
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-1-24 istio-gateways 10 ${cluster_context}
+$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway-main istio-gateways 10 ${cluster_context}
 #$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway istio-gateways 10 ${cluster_context}

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/tracing/istiod.yaml
@@ -15,17 +15,17 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.0
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-24
+        revision: main
         global:
           meshID: mesh1
           multiCluster:
             clusterName: cluster1
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.0-solo
+          tag: 1.24.2-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster1/httpbin-app/base/httpbin-in-mesh.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster1/httpbin-app/base/httpbin-in-mesh.yaml
@@ -40,7 +40,7 @@ spec:
       labels:
         app: in-mesh
         version: v1
-        istio.io/rev: 1-24
+        istio.io/rev: main
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     spec:

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster1/vars.env
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster1/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="cluster1"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster2/httpbin-app/base/httpbin-in-mesh.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster2/httpbin-app/base/httpbin-in-mesh.yaml
@@ -39,7 +39,7 @@ spec:
       labels:
         app: in-mesh
         version: v3
-        istio.io/rev: 1-24
+        istio.io/rev: main
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     spec:

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster2/vars.env
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster2/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="cluster2"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/README.md
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/README.md
@@ -16,6 +16,6 @@ When applied with `cluster1` and `cluster2` environments, here is a high level d
 
 ## Environment description
 - base:
-    - gloo mesh 2.6.6
-    - istio 1.24.0-solo (Helm)
-    - revision: 1-24
+    - gloo mesh 2.6.9
+    - istio 1.24.2-solo (Helm)
+    - revision: main

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/glootest.com/vars.env
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/glootest.com/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-24
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-24
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-app/base/httpbin-in-mesh.yaml
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/httpbin-app/base/httpbin-in-mesh.yaml
@@ -40,7 +40,7 @@ spec:
       labels:
         app: in-mesh
         version: v1
-        istio.io/rev: 1-24
+        istio.io/rev: main
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     spec:

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/vars.env
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster1/online-boutique-app/base/backend-apis-ns.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster1/online-boutique-app/base/backend-apis-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: backend-apis
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster1/online-boutique-app/base/web-ui-ns.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster1/online-boutique-app/base/web-ui-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: web-ui
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster1/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster1/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="cluster1"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster1/wildcard-host/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster1/wildcard-host/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="cluster1"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster2/online-boutique-app/base/backend-apis-ns.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster2/online-boutique-app/base/backend-apis-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: backend-apis
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster2/online-boutique-app/base/web-ui-ns.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster2/online-boutique-app/base/web-ui-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: web-ui
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster2/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster2/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="cluster2"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster2/wildcard-host/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster2/wildcard-host/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="cluster2"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/glootest.com/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/glootest.com/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/base/homer-portal-ns.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/base/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/base/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-24
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/glootest.com/homer-portal-ns.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/glootest.com/homer-portal-ns.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-24
+    istio.io/rev: main
 ---

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/glootest.com/homer-portal.yaml
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/homer-app/glootest.com/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-24
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/wildcard-host/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/wildcard-host/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.6"
+gloo_mesh_version="2.6.9"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-base.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.4
+    targetRevision: 1.24.2
   syncPolicy:
     automated:
       prune: true

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-cni.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-cni.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: cni
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.4
+    targetRevision: 1.24.2
     helm:
       values: |
         profile: ambient

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-ingressgateway.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.4
+    targetRevision: 1.24.2
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-ztunnel.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-ztunnel.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: ztunnel
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.4
+    targetRevision: 1.24.2
   syncPolicy:
     automated:
       prune: true

--- a/environments/istio/ambient-demo/core/istio/ambient/istiod.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.4
+    targetRevision: 1.24.2
     helm:
       values: |
         profile: ambient

--- a/environments/istio/ambient-demo/core/istio/gke/istio-cni.yaml
+++ b/environments/istio/ambient-demo/core/istio/gke/istio-cni.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: cni
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.4
+    targetRevision: 1.24.2
     helm:
       values: |
         profile: ambient

--- a/environments/istio/basic-demo/README.md
+++ b/environments/istio/basic-demo/README.md
@@ -10,5 +10,5 @@ The `istio/basic-demo` environment deploys cert-manager, Istio (with revisions),
 
 ## Environment description
 - base:
-    - istio 1.23.4 (Helm)
-    - revision: 1-23
+    - istio 1.24.2 (Helm)
+    - revision: main

--- a/environments/istio/basic-demo/homer/base/homer-portal-ns.yaml
+++ b/environments/istio/basic-demo/homer/base/homer-portal-ns.yaml
@@ -3,6 +3,6 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
   annotations:
     argocd.argoproj.io/sync-wave: "-5"

--- a/environments/istio/basic-demo/homer/base/homer-portal.yaml
+++ b/environments/istio/basic-demo/homer/base/homer-portal.yaml
@@ -48,7 +48,7 @@ spec:
         
         # -- Set labels on the pod
         #podLabels:
-        #  istio.io/rev: 1-23
+        #  istio.io/rev: main
         
         # -- Set annotations on the pod
         podAnnotations:

--- a/environments/istio/basic-demo/homer/lb-discovery/homer-portal-ns.yaml
+++ b/environments/istio/basic-demo/homer/lb-discovery/homer-portal-ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main

--- a/environments/istio/basic-demo/homer/lb-discovery/init.sh
+++ b/environments/istio/basic-demo/homer/lb-discovery/init.sh
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: homer-portal
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/environments/istio/basic-demo/httpbin/base/httpbin-ns.yaml
+++ b/environments/istio/basic-demo/httpbin/base/httpbin-ns.yaml
@@ -3,6 +3,6 @@ kind: Namespace
 metadata:
   name: httpbin
   labels:
-    istio.io/rev: 1-23
+    istio.io/rev: main
   annotations:
     argocd.argoproj.io/sync-wave: "-5"

--- a/environments/istio/basic-demo/istio/base/istio-base.yaml
+++ b/environments/istio/basic-demo/istio/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.4
+    targetRevision: 1.24.2
   syncPolicy:
     automated:
       prune: true

--- a/environments/istio/basic-demo/istio/base/istio-ingressgateway.yaml
+++ b/environments/istio/basic-demo/istio/base/istio-ingressgateway.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.4
+    targetRevision: 1.24.2
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set
         name: ""
         # revision declares which revision this gateway is a part of
-        revision: "1-23"
+        revision: "main"
         
         replicaCount: 1
         

--- a/environments/istio/basic-demo/istio/base/istiod.yaml
+++ b/environments/istio/basic-demo/istio/base/istiod.yaml
@@ -15,10 +15,10 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.23.4
+    targetRevision: 1.24.2
     helm:
       values: |
-        revision: 1-23
+        revision: main
         meshConfig:
           accessLogFile: /dev/stdout
           enableAutoMtls: true

--- a/environments/istio/basic-demo/istio/base/kiali.yaml
+++ b/environments/istio/basic-demo/istio/base/kiali.yaml
@@ -74,7 +74,7 @@ data:
       pod_annotations: {}
       pod_labels:
         sidecar.istio.io/inject: "true"
-        istio.io/rev: 1-23
+        istio.io/rev: main
       priority_class_name: ""
       replicas: 1
       resources:
@@ -116,9 +116,9 @@ data:
         url: http://prometheus:9090/prometheus
       ### add the following if using revisioned based istio installation
       istio:
-        config_map_name: istio-1-23
-        istio_sidecar_injector_config_map_name: istio-sidecar-injector-1-23
-        istiod_deployment_name: istiod-1-23
+        config_map_name: istio-main
+        istio_sidecar_injector_config_map_name: istio-sidecar-injector-main
+        istiod_deployment_name: istiod-main
         root_namespace: istio-system
     identity:
       cert_file: ""

--- a/environments/istio/basic-demo/istio/test.sh
+++ b/environments/istio/basic-demo/istio/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 $SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-ingressgateway istio-system 10 ${cluster_context}
-#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-1-23 istio-eastwest 10 ${cluster_context}
+#$SCRIPT_DIR/tools/wait-for-rollout.sh deployment istio-eastwestgateway-main istio-eastwest 10 ${cluster_context}


### PR DESCRIPTION
0.8.4 (1-31-25)
---
- update /gloo-gateway environments to use gloo-gateway 1.18.3 / istio 1.24.2 / `main` as revision tag / gloo-platform 2.6.9 (where used)
- update /gloo-gateway/oss environments to use OSS gloo-gateway 1.18.6
- update /gloo-mesh-core environments to use gloo-platform 2.6.9 / istio 1.24.2 / `main` as revision tag
- update /gloo-mesh-gateway environments to use gloo-platform 2.6.9 / istio 1.24.2 / `main` as revision tag
- update /gloo-platform environments to use gloo-platform 2.6.9 / istio 1.24.2 / `main` as revision tag
- update /istio environments to use istio 1.24.2 / `main` as revision tag