### PR TITLE
see CHANGELOG (0.8.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+0.8.5 (4-2-25)
+---
+- update /gloo-platform environments to use gloo-platform 2.7.1
+- update /gloo-mesh-gateway environments to use gloo-platform 2.7.1
+- update /gloo-mesh-core environments to use gloo-platform 2.7.1
+- update /istio environments to use istio 1.25.0
+- update /gloo-gateway environments to use gloo-gateway 1.18.9
+- update /gloo-gateway/oss environments to use OSS gloo-gateway 1.18.13
+
 0.8.5 (2-11-25)
 ---
 - Formatting fixes and updates to AI gateway demo scripts in `gloo-gateway/gateway-api/1.18/ai-gateway/field-demo/demos`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - update /istio environments to use istio 1.25.0
 - update /gloo-gateway environments to use gloo-gateway 1.18.9
 - update /gloo-gateway/oss environments to use OSS gloo-gateway 1.18.13
+- configure `telemetryCollector.mode: deployment` for `/gateway-api/1.18/with-gm-istio-helm-sidecar` environment to visualize Gloo Gateway metrics in the main dashboard
 
 0.8.5 (2-11-25)
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-0.8.5 (4-2-25)
+0.8.6 (4-2-25)
 ---
 - update /gloo-platform environments to use gloo-platform 2.7.1
 - update /gloo-mesh-gateway environments to use gloo-platform 2.7.1

--- a/environments/gloo-gateway/gateway-api/1.18/argo-rollouts/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/argo-rollouts/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -95,7 +95,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.3
+    targetRevision: 1.18.9
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/oss/gloo-oss-app/base/gloo-oss.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/oss/gloo-oss-app/base/gloo-oss.yaml
@@ -41,7 +41,7 @@ spec:
           # We don't need the discovery deployment for our Gloo Gateway demo
           enabled: false
     repoURL: https://storage.googleapis.com/solo-public-helm
-    targetRevision: 1.18.6
+    targetRevision: 1.18.13
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/portal-only/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/portal-only/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -98,7 +98,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.3
+    targetRevision: 1.18.9
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/standalone/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/standalone/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -95,7 +95,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.3
+    targetRevision: 1.18.9
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -107,7 +107,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.3
+    targetRevision: 1.18.9
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
     helm:
       values: |
         featureGates:

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-platform/base/gloo-platform-helm.yaml
@@ -94,16 +94,10 @@ spec:
             enabled: true
         telemetryGateway:
             enabled: true
-            #image:
-            #  pullPolicy: IfNotPresent
-            #  repository: gcr.io/gloo-mesh/gloo-otel-collector
-            #  tag: 2.7.1
         telemetryCollector:
             enabled: true
-            #image:
-            #  pullPolicy: IfNotPresent
-            #  repository: gcr.io/gloo-mesh/gloo-otel-collector
-            #  tag: 2.7.1
+            mode: deployment
+            replicaCount: 1
             config:
                 exporters:
                     otlp:

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/gloo-platform/base/gloo-platform-helm.yaml
@@ -97,13 +97,13 @@ spec:
             #image:
             #  pullPolicy: IfNotPresent
             #  repository: gcr.io/gloo-mesh/gloo-otel-collector
-            #  tag: 2.6.9
+            #  tag: 2.7.1
         telemetryCollector:
             enabled: true
             #image:
             #  pullPolicy: IfNotPresent
             #  repository: gcr.io/gloo-mesh/gloo-otel-collector
-            #  tag: 2.6.9
+            #  tag: 2.7.1
             config:
                 exporters:
                     otlp:
@@ -194,7 +194,7 @@ spec:
                                     - __meta_kubernetes_pod_phase
 
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/istio/base/istio-base.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/istio/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/istio/base/istiod.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-gm-istio-helm-sidecar/istio/base/istiod.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
         global:
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           accessLogFile: /dev/stdout
           enableAutoMtls: true

--- a/environments/gloo-gateway/gateway-api/1.18/with-ilm-ambient/base/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-ilm-ambient/base/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -95,7 +95,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.3
+    targetRevision: 1.18.9
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/with-ilm-ambient/singlecluster/istio/ambient/servicemeshcontroller.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-ilm-ambient/singlecluster/istio/ambient/servicemeshcontroller.yaml
@@ -3,6 +3,6 @@ kind: ServiceMeshController
 metadata:
   name: ambient
 spec:
-  version: 1.24.2
+  version: 1.25.0
   dataplaneMode: Ambient
   installNamespace: istio-system

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -95,7 +95,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.3
+    targetRevision: 1.18.9
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-base.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-cni.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-cni.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: cni
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         profile: ambient

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-ingressgateway.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-ztunnel.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istio-ztunnel.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: ztunnel
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istiod.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/ambient/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         profile: ambient

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/gke/istio-cni.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-ambient/istio/gke/istio-cni.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: cni
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         profile: ambient

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/gloo-enterprise-app/base/gloo-enterprise.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/gloo-enterprise-app/base/gloo-enterprise.yaml
@@ -107,7 +107,7 @@ spec:
               deployment:
                 logLevel: debug
     repoURL: http://storage.googleapis.com/gloo-ee-helm
-    targetRevision: 1.18.3
+    targetRevision: 1.18.9
   syncPolicy:
     automated:
       prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/istio/base/istio-base.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/istio/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/istio/base/istiod.yaml
+++ b/environments/gloo-gateway/gateway-api/1.18/with-istio-helm-sidecar/istio/base/istiod.yaml
@@ -15,13 +15,13 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
         global:
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           accessLogFile: /dev/stdout
           enableAutoMtls: true

--- a/environments/gloo-mesh-core/additional-cluster-1/README.md
+++ b/environments/gloo-mesh-core/additional-cluster-1/README.md
@@ -9,6 +9,6 @@ The `gloo-mesh-core/additional-cluster-1` environment bootstraps an additional w
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main

--- a/environments/gloo-mesh-core/additional-cluster-1/gloo-agent/base/gloo-platform-crds.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/gloo-agent/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/additional-cluster-1/gloo-agent/init.sh
+++ b/environments/gloo-mesh-core/additional-cluster-1/gloo-agent/init.sh
@@ -7,7 +7,7 @@ echo "deploy and register gloo-mesh agent and addons"
 if [[ ${gloo_mesh_version} == "" ]]
   then
     # provide gloo_mesh_version variable
-    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.9):"
+    echo "Please provide the gloo_mesh_version to use (i.e. 2.7.1):"
     read gloo_mesh_version
 fi
 
@@ -116,7 +116,7 @@ spec:
             runAsSidecar: true  
                 
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true
@@ -172,7 +172,7 @@ spec:
                   name: cilium-run
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-1/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: additional-cluster-1
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           trustDomain: additional-cluster-1
           accessLogFile: /dev/stdout

--- a/environments/gloo-mesh-core/additional-cluster-1/vars.env
+++ b/environments/gloo-mesh-core/additional-cluster-1/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="additional-cluster-1"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-mesh-core/additional-cluster-2/README.md
+++ b/environments/gloo-mesh-core/additional-cluster-2/README.md
@@ -9,6 +9,6 @@ The `gloo-mesh-core/additional-cluster-2` environment bootstraps an additional w
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main

--- a/environments/gloo-mesh-core/additional-cluster-2/gloo-agent/base/gloo-platform-crds.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/gloo-agent/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/additional-cluster-2/gloo-agent/init.sh
+++ b/environments/gloo-mesh-core/additional-cluster-2/gloo-agent/init.sh
@@ -7,7 +7,7 @@ echo "deploy and register gloo-mesh agent and addons"
 if [[ ${gloo_mesh_version} == "" ]]
   then
     # provide gloo_mesh_version variable
-    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.9):"
+    echo "Please provide the gloo_mesh_version to use (i.e. 2.7.1):"
     read gloo_mesh_version
 fi
 
@@ -116,7 +116,7 @@ spec:
             runAsSidecar: true  
                 
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true
@@ -172,7 +172,7 @@ spec:
                   name: cilium-run
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-core/additional-cluster-2/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: additional-cluster-2
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           trustDomain: additional-cluster-2
           accessLogFile: /dev/stdout

--- a/environments/gloo-mesh-core/additional-cluster-2/vars.env
+++ b/environments/gloo-mesh-core/additional-cluster-2/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="additional-cluster-2"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-mesh-core/singlecluster/README.md
+++ b/environments/gloo-mesh-core/singlecluster/README.md
@@ -8,6 +8,6 @@ The `gloo-mesh-core/singlecluster` environment deploys the core components of a 
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main

--- a/environments/gloo-mesh-core/singlecluster/gloo-mesh-core/base/gloo-platform-crds.yaml
+++ b/environments/gloo-mesh-core/singlecluster/gloo-mesh-core/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/singlecluster/gloo-mesh-core/base/gloo-platform-helm.yaml
+++ b/environments/gloo-mesh-core/singlecluster/gloo-mesh-core/base/gloo-platform-helm.yaml
@@ -98,7 +98,7 @@ spec:
                   name: cilium-run
 
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-mesh-core/singlecluster/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-core/singlecluster/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: mgmt
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           trustDomain: mgmt
           accessLogFile: /dev/stdout

--- a/environments/gloo-mesh-gateway/bookinfo/README.md
+++ b/environments/gloo-mesh-gateway/bookinfo/README.md
@@ -10,6 +10,6 @@ The `gloo-gateway/backstage-bookinfo-httpbin` environment deploys the core compo
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main

--- a/environments/gloo-mesh-gateway/bookinfo/ilm/README.md
+++ b/environments/gloo-mesh-gateway/bookinfo/ilm/README.md
@@ -29,8 +29,8 @@ The `gloo-gateway/backstage-bookinfo-httpbin` environment deploys the core compo
 
 ## Overlay description
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main
 
 ## Application description

--- a/environments/gloo-mesh-gateway/core/README.md
+++ b/environments/gloo-mesh-gateway/core/README.md
@@ -10,6 +10,6 @@ The `gloo-gateway/core` environment deploys the core components of a single clus
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main

--- a/environments/gloo-mesh-gateway/core/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-mesh-gateway/core/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-gateway/core/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-mesh-gateway/core/gloo-platform/base/gloo-platform-helm.yaml
@@ -91,16 +91,8 @@ spec:
             enabled: true
         telemetryGateway:
             enabled: true
-            #image:
-            #  pullPolicy: IfNotPresent
-            #  repository: gcr.io/gloo-mesh/gloo-otel-collector
-            #  tag: 2.7.1
         telemetryCollector:
             enabled: true
-            #image:
-            #  pullPolicy: IfNotPresent
-            #  repository: gcr.io/gloo-mesh/gloo-otel-collector
-            #  tag: 2.7.1
             config:
                 exporters:
                     otlp:

--- a/environments/gloo-mesh-gateway/core/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-mesh-gateway/core/gloo-platform/base/gloo-platform-helm.yaml
@@ -94,13 +94,13 @@ spec:
             #image:
             #  pullPolicy: IfNotPresent
             #  repository: gcr.io/gloo-mesh/gloo-otel-collector
-            #  tag: 2.6.9
+            #  tag: 2.7.1
         telemetryCollector:
             enabled: true
             #image:
             #  pullPolicy: IfNotPresent
             #  repository: gcr.io/gloo-mesh/gloo-otel-collector
-            #  tag: 2.6.9
+            #  tag: 2.7.1
             config:
                 exporters:
                     otlp:
@@ -191,7 +191,7 @@ spec:
                                     - __meta_kubernetes_pod_phase
 
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-gateway/core/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-mesh-gateway/core/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-mesh-gateway/core/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-mesh-gateway/core/istio/helm/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-mesh-gateway/core/istio/helm/base/istiod.yaml
+++ b/environments/gloo-mesh-gateway/core/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: mgmt
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           trustDomain: mgmt
           accessLogFile: /dev/stdout

--- a/environments/gloo-mesh-gateway/httpbin/README.md
+++ b/environments/gloo-mesh-gateway/httpbin/README.md
@@ -10,6 +10,6 @@ The `gloo-gateway/httpbin` environment deploys the core components of a single c
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main

--- a/environments/gloo-mesh-gateway/onlineboutique/README.md
+++ b/environments/gloo-mesh-gateway/onlineboutique/README.md
@@ -10,6 +10,6 @@ The `gloo-gateway/onlineboutique` environment deploys the core components of a s
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main

--- a/environments/gloo-mesh-gateway/onlineboutique/glootest.com/README.md
+++ b/environments/gloo-mesh-gateway/onlineboutique/glootest.com/README.md
@@ -23,8 +23,8 @@ The `gloo-gateway/onlineboutique` environment deploys the core components of a s
 
 ## Overlay description
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main
 
 ## Application description

--- a/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/README.md
+++ b/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/README.md
@@ -10,6 +10,6 @@ The `gloo-gateway/progressive-delivery-argo-rollouts` environment deploys the co
 
 ## Environment descriptions
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main

--- a/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/glootest.com/README.md
+++ b/environments/gloo-mesh-gateway/progressive-delivery-argo-rollouts/glootest.com/README.md
@@ -23,8 +23,8 @@ The `gloo-gateway/onlineboutique` environment deploys the core components of a s
 
 ## Overlay description
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main
 
 ## Application description

--- a/environments/gloo-platform/core/cluster1/README.md
+++ b/environments/gloo-platform/core/cluster1/README.md
@@ -10,6 +10,6 @@ The `gloo-platform/core/cluster1` environment deploys the `cluster1` worker for 
 
 ## Environment description
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main

--- a/environments/gloo-platform/core/cluster1/gloo-platform/base/gloo-platform-addons.yaml
+++ b/environments/gloo-platform/core/cluster1/gloo-platform/base/gloo-platform-addons.yaml
@@ -23,7 +23,7 @@ spec:
         rateLimiter:
             enabled: true
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/cluster1/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-platform/core/cluster1/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/cluster1/gloo-platform/init.sh
+++ b/environments/gloo-platform/core/cluster1/gloo-platform/init.sh
@@ -7,7 +7,7 @@ echo "deploy and register gloo-mesh agent and addons"
 if [[ ${gloo_mesh_version} == "" ]]
   then
     # provide gloo_mesh_version variable
-    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.9):"
+    echo "Please provide the gloo_mesh_version to use (i.e. 2.7.1):"
     read gloo_mesh_version
 fi
 
@@ -78,7 +78,7 @@ spec:
             runAsSidecar: true  
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true
@@ -126,7 +126,7 @@ spec:
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.9
+              tag: 2.7.1
             config:
                 exporters:
                     otlp:
@@ -148,7 +148,7 @@ spec:
                   name: cilium-run
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/cluster1/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/base/istio-eastwestgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/core/cluster1/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: cluster1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           trustDomain: cluster1
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/core/cluster1/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/cluster1/istio/helm/tracing/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: cluster1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/core/cluster1/vars.env
+++ b/environments/gloo-platform/core/cluster1/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="cluster1"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/core/cluster2/README.md
+++ b/environments/gloo-platform/core/cluster2/README.md
@@ -10,6 +10,6 @@ The `gloo-platform/core/cluster2` environment deploys the `cluster2` worker for 
 
 ## Environment description
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main

--- a/environments/gloo-platform/core/cluster2/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-platform/core/cluster2/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/cluster2/gloo-platform/init.sh
+++ b/environments/gloo-platform/core/cluster2/gloo-platform/init.sh
@@ -7,7 +7,7 @@ echo "deploy and register gloo-mesh agent and addons"
 if [[ ${gloo_mesh_version} == "" ]]
   then
     # provide gloo_mesh_version variable
-    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.9):"
+    echo "Please provide the gloo_mesh_version to use (i.e. 2.7.1):"
     read gloo_mesh_version
 fi
 
@@ -78,7 +78,7 @@ spec:
             runAsSidecar: true  
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true
@@ -126,7 +126,7 @@ spec:
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.9
+              tag: 2.7.1
             config:
                 exporters:
                     otlp:
@@ -148,7 +148,7 @@ spec:
                   name: cilium-run
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/cluster2/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/helm/base/istio-eastwestgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/core/cluster2/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/cluster2/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster2
           network: cluster2
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           trustDomain: cluster2
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/core/cluster2/vars.env
+++ b/environments/gloo-platform/core/cluster2/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="cluster2"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/core/mgmt/README.md
+++ b/environments/gloo-platform/core/mgmt/README.md
@@ -18,6 +18,6 @@ When applied with `cluster1` and `cluster2` environments, here is a high level d
 
 ## Environment description
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main

--- a/environments/gloo-platform/core/mgmt/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-platform/core/mgmt/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/mgmt/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-platform/core/mgmt/gloo-platform/base/gloo-platform-helm.yaml
@@ -85,7 +85,7 @@ spec:
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.9
+              tag: 2.7.1
         telemetryGatewayCustomization:
             disableCertGeneration: true
         telemetryCollector:
@@ -102,7 +102,7 @@ spec:
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.9
+              tag: 2.7.1
             config:
                 exporters:
                     otlp:
@@ -124,7 +124,7 @@ spec:
                   name: cilium-run
         
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/mgmt/glootest.com/vars.env
+++ b/environments/gloo-platform/core/mgmt/glootest.com/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/istio-eastwestgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/core/mgmt/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: mgmt
           network: mgmt
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           trustDomain: mgmt
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/core/mgmt/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/mgmt/istio/helm/tracing/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: mgmt
           network: mgmt
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/core/mgmt/vars.env
+++ b/environments/gloo-platform/core/mgmt/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/core/shared-components/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           trustDomain: cluster1
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/core/shared-components/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/core/shared-components/istio/helm/tracing/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/README.md
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/README.md
@@ -10,6 +10,6 @@ The `gloo-platform/core/cluster1` environment deploys the `cluster1` worker for 
 
 ## Environment description
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/gloo-platform/base/gloo-platform-addons.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/gloo-platform/base/gloo-platform-addons.yaml
@@ -23,7 +23,7 @@ spec:
         rateLimiter:
             enabled: true
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/gloo-platform/init.sh
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/gloo-platform/init.sh
@@ -7,7 +7,7 @@ echo "deploy and register gloo-mesh agent and addons"
 if [[ ${gloo_mesh_version} == "" ]]
   then
     # provide gloo_mesh_version variable
-    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.9):"
+    echo "Please provide the gloo_mesh_version to use (i.e. 2.7.1):"
     read gloo_mesh_version
 fi
 
@@ -78,7 +78,7 @@ spec:
             runAsSidecar: true  
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true
@@ -126,7 +126,7 @@ spec:
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.9
+              tag: 2.7.1
             config:
                 exporters:
                     otlp:
@@ -148,7 +148,7 @@ spec:
                   name: cilium-run
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istio-eastwestgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: cluster1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           trustDomain: cluster1
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/istio/helm/tracing/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: cluster1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/vars.env
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster1/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="cluster1"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/README.md
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/README.md
@@ -10,6 +10,6 @@ The `gloo-platform/core/cluster2` environment deploys the `cluster2` worker for 
 
 ## Environment description
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/gloo-platform/init.sh
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/gloo-platform/init.sh
@@ -7,7 +7,7 @@ echo "deploy and register gloo-mesh agent and addons"
 if [[ ${gloo_mesh_version} == "" ]]
   then
     # provide gloo_mesh_version variable
-    echo "Please provide the gloo_mesh_version to use (i.e. 2.6.9):"
+    echo "Please provide the gloo_mesh_version to use (i.e. 2.7.1):"
     read gloo_mesh_version
 fi
 
@@ -78,7 +78,7 @@ spec:
             runAsSidecar: true  
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true
@@ -126,7 +126,7 @@ spec:
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.9
+              tag: 2.7.1
             config:
                 exporters:
                     otlp:
@@ -148,7 +148,7 @@ spec:
                   name: cilium-run
                   
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istio-eastwestgateway.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istio-eastwestgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster2
           network: cluster2
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           trustDomain: cluster2
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/istio/helm/tracing/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster2
           network: cluster2
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/vars.env
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/cluster2/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="cluster2"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/README.md
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/README.md
@@ -18,6 +18,6 @@ When applied with `cluster1` and `cluster2` environments, here is a high level d
 
 ## Environment description
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform/base/gloo-platform-crds.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform/base/gloo-platform-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
     helm:
       values: |
         featureGates:

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform/base/gloo-platform-helm.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/gloo-platform/base/gloo-platform-helm.yaml
@@ -87,7 +87,7 @@ spec:
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.9
+              tag: 2.7.1
         telemetryGatewayCustomization:
             disableCertGeneration: true
         telemetryCollector:
@@ -104,7 +104,7 @@ spec:
             image:
               pullPolicy: IfNotPresent
               repository: gcr.io/gloo-mesh/gloo-otel-collector
-              tag: 2.6.9
+              tag: 2.7.1
             config:
                 exporters:
                     otlp:
@@ -126,7 +126,7 @@ spec:
                   name: cilium-run
         
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.6.9
+    targetRevision: 2.7.1
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/glootest.com/vars.env
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/glootest.com/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/vars.env
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/mgmt/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istio-base.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istio-ingressgateway.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           trustDomain: cluster1
           accessLogFile: /dev/stdout

--- a/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/tracing/istiod.yaml
+++ b/environments/gloo-platform/gwapi-mgmt-gm-workers/shared-components/istio/helm/tracing/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main
@@ -25,7 +25,7 @@ spec:
             clusterName: cluster1
           network: network1
           hub: us-docker.pkg.dev/gloo-mesh/istio-workshops
-          tag: 1.24.2-solo
+          tag: 1.25.0-solo
         meshConfig:
           enableTracing: true
           extensionProviders:

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster1/vars.env
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster1/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="cluster1"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster2/vars.env
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/cluster2/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="cluster2"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/README.md
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/README.md
@@ -16,6 +16,6 @@ When applied with `cluster1` and `cluster2` environments, here is a high level d
 
 ## Environment description
 - base:
-    - gloo mesh 2.6.9
-    - istio 1.24.2-solo (Helm)
+    - gloo mesh 2.7.1
+    - istio 1.25.0-solo (Helm)
     - revision: main

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/glootest.com/vars.env
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/glootest.com/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/vars.env
+++ b/environments/gloo-platform/multicluster-bookinfo-httpbin/mgmt/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster1/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster1/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="cluster1"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster1/wildcard-host/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster1/wildcard-host/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="cluster1"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster2/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster2/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="cluster2"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/cluster2/wildcard-host/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/cluster2/wildcard-host/vars.env
@@ -4,7 +4,7 @@
 # please use `kubectl config rename-contexts <current_context> <target_context>` to
 # rename your context if necessary
 
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="cluster2"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/glootest.com/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/glootest.com/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/gloo-platform/multicluster-onlineboutique/mgmt/wildcard-host/vars.env
+++ b/environments/gloo-platform/multicluster-onlineboutique/mgmt/wildcard-host/vars.env
@@ -5,7 +5,7 @@
 # rename your context if necessary
 
 license_key="$GLOO_PLATFORM_LICENSE_KEY"
-gloo_mesh_version="2.6.9"
+gloo_mesh_version="2.7.1"
 cluster_context="mgmt"
 mgmt_context="mgmt"
 parent_app_sync="true"

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-base.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-cni.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-cni.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: cni
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         profile: ambient

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-ingressgateway.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/istio/ambient-demo/core/istio/ambient/istio-ztunnel.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istio-ztunnel.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: ztunnel
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/istio/ambient-demo/core/istio/ambient/istiod.yaml
+++ b/environments/istio/ambient-demo/core/istio/ambient/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         profile: ambient

--- a/environments/istio/ambient-demo/core/istio/gke/istio-cni.yaml
+++ b/environments/istio/ambient-demo/core/istio/gke/istio-cni.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: cni
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         profile: ambient

--- a/environments/istio/basic-demo/README.md
+++ b/environments/istio/basic-demo/README.md
@@ -10,5 +10,5 @@ The `istio/basic-demo` environment deploys cert-manager, Istio (with revisions),
 
 ## Environment description
 - base:
-    - istio 1.24.2 (Helm)
+    - istio 1.25.0 (Helm)
     - revision: main

--- a/environments/istio/basic-demo/istio/base/istio-base.yaml
+++ b/environments/istio/basic-demo/istio/base/istio-base.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: base
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
   syncPolicy:
     automated:
       prune: true

--- a/environments/istio/basic-demo/istio/base/istio-ingressgateway.yaml
+++ b/environments/istio/basic-demo/istio/base/istio-ingressgateway.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: gateway
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         # Name allows overriding the release name. Generally this should not be set

--- a/environments/istio/basic-demo/istio/base/istiod.yaml
+++ b/environments/istio/basic-demo/istio/base/istiod.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: istiod
     repoURL: https://istio-release.storage.googleapis.com/charts
-    targetRevision: 1.24.2
+    targetRevision: 1.25.0
     helm:
       values: |
         revision: main


### PR DESCRIPTION
0.8.6 (4-2-25)
---
- update /gloo-platform environments to use gloo-platform 2.7.1
- update /gloo-mesh-gateway environments to use gloo-platform 2.7.1
- update /gloo-mesh-core environments to use gloo-platform 2.7.1
- update /istio environments to use istio 1.25.0
- update /gloo-gateway environments to use gloo-gateway 1.18.9
- update /gloo-gateway/oss environments to use OSS gloo-gateway 1.18.13
- configure `telemetryCollector.mode: deployment` for `/gateway-api/1.18/with-gm-istio-helm-sidecar` environment to visualize Gloo Gateway metrics in the main dashboard